### PR TITLE
Feat: Discovery Phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,6 @@
         </dependencies>
     </dependencyManagement>
 
-
     <build>
         <pluginManagement>
             <plugins>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -70,7 +70,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>io.julian.server.Main</mainClass>
+                            <mainClass>io.julian.ExampleDistributedAlgorithm</mainClass>
                         </manifest>
                     </archive>
                     <descriptorRefs>

--- a/zookeeper/pom.xml
+++ b/zookeeper/pom.xml
@@ -69,7 +69,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>io.julian.zookeeper.Main</mainClass>
+                            <mainClass>io.julian.ZookeeperAlgorithm</mainClass>
                         </manifest>
                     </archive>
                     <descriptorRefs>

--- a/zookeeper/src/main/java/io/julian/ZookeeperAlgorithm.java
+++ b/zookeeper/src/main/java/io/julian/ZookeeperAlgorithm.java
@@ -45,7 +45,7 @@ public class ZookeeperAlgorithm extends DistributedAlgorithm {
         Class messageClass = getMessageClass(message.getMetadata());
         if (message.getMetadata().getRequest().equals(HTTPRequest.UNKNOWN)) {
             if (messageClass == ShortenedExchange.class) {
-                log.info("Received state update but not doing anything yet");
+                log.info("Received state update");
                 this.writeHandler.handleCoordinationMessage(message);
             } else {
                 addCandidateInformation(message);
@@ -150,5 +150,8 @@ public class ZookeeperAlgorithm extends DistributedAlgorithm {
         CandidateInformationRegistry registry = new CandidateInformationRegistry();
         registry.addCandidateInformation(new CandidateInformation(configuration.getServerHost(), configuration.getServerPort(), candidateNumber));
         return log.traceExit(registry);
+    }
+
+    public static void main(final String[] args) {
     }
 }

--- a/zookeeper/src/main/java/io/julian/zookeeper/controller/State.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/controller/State.java
@@ -24,6 +24,8 @@ public class State {
     private final AtomicInteger lastAcceptedIndex = new AtomicInteger();
     private final Vertx vertx;
     private final MessageStore messageStore;
+    private final AtomicInteger leaderEpoch = new AtomicInteger();
+    private final AtomicInteger counter = new AtomicInteger();
 
     public State(final Vertx vertx, final MessageStore messageStore) {
         this.vertx = vertx;
@@ -131,12 +133,13 @@ public class State {
 
     public void setLastAcceptedIndex(final int index) {
         log.traceEntry(() -> index);
-        if (lastAcceptedIndex.get() < index) {
-            log.info(String.format("Setting last accepted index to '%d'", index));
-            lastAcceptedIndex.set(index);
+        final int nextIndex = index + 1;
+        if (lastAcceptedIndex.get() < nextIndex) {
+            log.info(String.format("Setting last accepted index to '%d'", nextIndex));
+            lastAcceptedIndex.set(nextIndex);
         } else {
             log.info(String.format("Skipping setting last accepted index to '%d' as current index '%s' is higher",
-                index, lastAcceptedIndex.get()));
+                nextIndex, lastAcceptedIndex.get()));
         }
         log.traceExit();
     }
@@ -154,5 +157,32 @@ public class State {
     public int getLastAcceptedIndex() {
         log.traceEntry();
         return log.traceExit(lastAcceptedIndex.get());
+    }
+
+    public int getLeaderEpoch() {
+        log.traceEntry();
+        return log.traceExit(leaderEpoch.get());
+    }
+
+    public int getCounter() {
+        log.traceEntry();
+        return log.traceExit(counter.get());
+    }
+
+    public int getAndIncrementCounter() {
+        log.traceEntry();
+        return log.traceExit(counter.getAndIncrement());
+    }
+
+    public void setLeaderEpoch(final int epoch) {
+        log.traceEntry(() -> epoch);
+        leaderEpoch.set(epoch);
+        log.traceExit();
+    }
+
+    public void setCounter(final int counter) {
+        log.traceEntry(() -> counter);
+        this.counter.set(counter);
+        log.traceExit();
     }
 }

--- a/zookeeper/src/main/java/io/julian/zookeeper/discovery/DiscoveryHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/discovery/DiscoveryHandler.java
@@ -1,5 +1,83 @@
 package io.julian.zookeeper.discovery;
 
-public class DiscoveryHandler {
+import io.julian.server.api.client.RegistryManager;
+import io.julian.server.api.client.ServerClient;
+import io.julian.server.components.Controller;
+import io.julian.server.models.coordination.CoordinationMessage;
+import io.julian.zookeeper.controller.State;
+import io.julian.zookeeper.election.CandidateInformationRegistry;
+import io.julian.zookeeper.election.LeadershipElectionHandler;
+import io.julian.zookeeper.models.Zxid;
+import io.vertx.core.Future;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+public class DiscoveryHandler {
+    public static final String NOT_ENOUGH_RESPONSES_ERROR = "Leader has not received enough follower ZXID responses";
+
+    private final static Logger log = LogManager.getLogger(DiscoveryHandler.class);
+    private final Controller controller;
+    private final FollowerDiscoveryHandler followerHandler;
+    private final LeaderDiscoveryHandler leaderHandler;
+    private boolean hasBroadcastFollowerZXID = false;
+
+    public DiscoveryHandler(final Controller controller, final State state, final CandidateInformationRegistry candidateInformationRegistry,
+                            final RegistryManager registryManager, final ServerClient client) {
+        this.controller = controller;
+        this.followerHandler = new FollowerDiscoveryHandler(state, candidateInformationRegistry, client);
+        this.leaderHandler = new LeaderDiscoveryHandler(state, registryManager, client);
+    }
+
+    public void reset() {
+        log.traceEntry();
+        log.info("Resetting DiscoveryHandler");
+        hasBroadcastFollowerZXID = controller.getLabel().equals(LeadershipElectionHandler.FOLLOWER_LABEL);
+        leaderHandler.reset();
+        log.traceExit();
+    }
+
+    public Future<Void> broadcastToFollowers() {
+        log.traceEntry();
+        hasBroadcastFollowerZXID = true;
+        return log.traceExit(leaderHandler.broadcastGatherZXID());
+    }
+
+    public Future<Void> handleCoordinationMessage(final CoordinationMessage coordinationMessage) {
+        log.traceEntry(() -> coordinationMessage);
+        if (controller.getLabel().equals(LeadershipElectionHandler.LEADER_LABEL)) {
+            final Zxid id = coordinationMessage.getDefinition().mapTo(Zxid.class);
+            log.info("Leader processing follower ZXID broadcast");
+            leaderHandler.processFollowerZXID(id);
+            if (leaderHandler.hasEnoughResponses()) {
+                log.info("Leader has received ZXID broadcast from all followers");
+                leaderHandler.updateStateEpochAndCounter();
+                return log.traceExit(Future.succeededFuture());
+            }
+            return log.traceExit(Future.failedFuture(NOT_ENOUGH_RESPONSES_ERROR));
+        } else {
+            log.info("Follower sending latest ZXID to leader");
+            return log.traceExit(followerHandler.replyToLeader());
+        }
+    }
+
+    public boolean hasBroadcastFollowerZXID() {
+        log.traceEntry();
+        return log.traceExit(hasBroadcastFollowerZXID);
+    }
+
+    public State getState() {
+        log.traceEntry();
+        return log.traceExit(leaderHandler.getState());
+    }
+
+    public LeaderDiscoveryHandler getLeaderHandler() {
+        log.traceEntry();
+        return log.traceExit(leaderHandler);
+    }
+
+
+    public FollowerDiscoveryHandler getFollowerHandler() {
+        log.traceEntry();
+        return log.traceExit(followerHandler);
+    }
 }

--- a/zookeeper/src/main/java/io/julian/zookeeper/discovery/DiscoveryHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/discovery/DiscoveryHandler.java
@@ -1,0 +1,5 @@
+package io.julian.zookeeper.discovery;
+
+public class DiscoveryHandler {
+
+}

--- a/zookeeper/src/main/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandler.java
@@ -9,12 +9,12 @@ import io.julian.zookeeper.election.CandidateInformationRegistry;
 import io.julian.zookeeper.models.Zxid;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import lombok.Getter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+@Getter
 public class FollowerDiscoveryHandler {
-    public final static String ZXID_FOLLOWER_TYPE = "ZXID_FOLLOWER";
-
     private final static Logger log = LogManager.getLogger(FollowerDiscoveryHandler.class);
     private final State state;
     private final CandidateInformationRegistry registry;
@@ -44,10 +44,18 @@ public class FollowerDiscoveryHandler {
         return log.traceExit(post.future());
     }
 
+    public void updateToLeaderState(final Zxid id) {
+        log.traceEntry(() -> id);
+        log.info(String.format("Updating follower ZXID to leader's %s", id));
+        state.setCounter(id.getCounter());
+        state.setLeaderEpoch(id.getEpoch());
+        log.traceExit();
+    }
+
     public CoordinationMessage createCoordinationMessage(final Zxid id) {
         log.traceEntry(() -> id);
         return log.traceExit(new CoordinationMessage(
-            new CoordinationMetadata(HTTPRequest.UNKNOWN, "", ZXID_FOLLOWER_TYPE),
+            new CoordinationMetadata(HTTPRequest.UNKNOWN, "", DiscoveryHandler.DISCOVERY_TYPE),
             null,
             id.toJson()));
     }

--- a/zookeeper/src/main/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandler.java
@@ -1,0 +1,54 @@
+package io.julian.zookeeper.discovery;
+
+import io.julian.server.api.client.ServerClient;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.coordination.CoordinationMessage;
+import io.julian.server.models.coordination.CoordinationMetadata;
+import io.julian.zookeeper.controller.State;
+import io.julian.zookeeper.election.CandidateInformationRegistry;
+import io.julian.zookeeper.models.Zxid;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class FollowerDiscoveryHandler {
+    public final static String ZXID_FOLLOWER_TYPE = "ZXID_FOLLOWER";
+
+    private final static Logger log = LogManager.getLogger(FollowerDiscoveryHandler.class);
+    private final State state;
+    private final CandidateInformationRegistry registry;
+    private final ServerClient client;
+
+    public FollowerDiscoveryHandler(final State state, final CandidateInformationRegistry registry, final ServerClient client) {
+        this.state = state;
+        this.registry = registry;
+        this.client = client;
+    }
+
+    public Future<Void> replyToLeader() {
+        log.traceEntry();
+        final Zxid id = new Zxid(state.getLeaderEpoch(), state.getCounter());
+        log.info(String.format("Sending leader latest ZXID %s", id));
+        Promise<Void> post = Promise.promise();
+        client.sendCoordinateMessageToServer(registry.getLeaderServerConfiguration(), createCoordinationMessage(id))
+            .onSuccess(v -> {
+                log.info(String.format("Successfully sent leader latest ZXID %s", id));
+                post.complete();
+            })
+            .onFailure(cause -> {
+                log.info(String.format("Unsuccessfully sent leader latest ZXID %s", id));
+                log.error(cause);
+                post.fail(cause);
+            });
+        return log.traceExit(post.future());
+    }
+
+    public CoordinationMessage createCoordinationMessage(final Zxid id) {
+        log.traceEntry(() -> id);
+        return log.traceExit(new CoordinationMessage(
+            new CoordinationMetadata(HTTPRequest.UNKNOWN, "", ZXID_FOLLOWER_TYPE),
+            null,
+            id.toJson()));
+    }
+}

--- a/zookeeper/src/main/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandler.java
@@ -1,0 +1,84 @@
+package io.julian.zookeeper.discovery;
+
+import io.julian.server.api.client.RegistryManager;
+import io.julian.server.api.client.ServerClient;
+import io.julian.zookeeper.controller.State;
+import io.julian.zookeeper.election.LeadershipElectionHandler;
+import io.julian.zookeeper.models.Zxid;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class LeaderDiscoveryHandler {
+    private final static Logger log = LogManager.getLogger(LeadershipElectionHandler.class);
+
+    private final AtomicInteger epochTracker = new AtomicInteger();
+    private final AtomicInteger counterTracker = new AtomicInteger();
+
+    private final AtomicInteger followerResponses = new AtomicInteger();
+    private final State state;
+    private final ServerClient client;
+    private final RegistryManager manager;
+
+    public LeaderDiscoveryHandler(final State state, final ServerClient client, final RegistryManager manager) {
+        this.state = state;
+        this.client = client;
+        this.manager = manager;
+    }
+
+    public void processFollowerEpoch(final Zxid id) {
+        log.traceEntry(() -> id);
+        log.info(String.format("Processing follower epoch response '%s'", id));
+        followerResponses.incrementAndGet();
+        if (epochTracker.get() < id.getEpoch()) {
+            epochTracker.set(id.getEpoch());
+            counterTracker.set(id.getCounter());
+        } else if (epochTracker.get() == id.getEpoch() && counterTracker.get() < id.getCounter()) {
+            counterTracker.set(id.getCounter());
+        }
+        log.traceExit();
+    }
+
+    public void updateStateEpochAndCounter() {
+        log.traceEntry();
+        log.info(String.format("Updating leader epoch to '%d' and counter to '%d'", epochTracker.get(), counterTracker.get()));
+        state.setLeaderEpoch(epochTracker.get());
+        state.setCounter(counterTracker.get());
+        log.traceExit();
+    }
+
+    public boolean hasEnoughResponses() {
+        log.traceEntry();
+        return log.traceExit(manager.getOtherServers().size() == followerResponses.get());
+    }
+
+    public void reset() {
+        log.traceEntry();
+        log.info("Resetting epoch and follower tracker");
+        followerResponses.set(0);
+        epochTracker.set(state.getLeaderEpoch());
+        counterTracker.set(state.getCounter());
+        log.traceExit();
+    }
+
+    public int getEpoch() {
+        log.traceEntry();
+        return log.traceExit(epochTracker.get());
+    }
+
+    public int getFollowerResponses() {
+        log.traceEntry();
+        return log.traceExit(followerResponses.get());
+    }
+
+    public int getCounter() {
+        log.traceEntry();
+        return log.traceExit(counterTracker.get());
+    }
+
+    public State getState() {
+        log.traceEntry();
+        return log.traceExit(this.state);
+    }
+}

--- a/zookeeper/src/main/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandler.java
@@ -28,16 +28,16 @@ public class LeaderDiscoveryHandler {
 
     private final AtomicInteger followerResponses = new AtomicInteger();
     private final State state;
-    private final ServerClient client;
     private final RegistryManager manager;
+    private final ServerClient client;
 
-    public LeaderDiscoveryHandler(final State state, final ServerClient client, final RegistryManager manager) {
+    public LeaderDiscoveryHandler(final State state, final RegistryManager manager, final ServerClient client) {
         this.state = state;
-        this.client = client;
         this.manager = manager;
+        this.client = client;
     }
 
-    public void processFollowerEpoch(final Zxid id) {
+    public void processFollowerZXID(final Zxid id) {
         log.traceEntry(() -> id);
         log.info(String.format("Processing follower epoch response '%s'", id));
         followerResponses.incrementAndGet();

--- a/zookeeper/src/main/java/io/julian/zookeeper/write/WriteHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/write/WriteHandler.java
@@ -20,7 +20,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class WriteHandler {
     private static final Logger log = LogManager.getLogger(WriteHandler.class);
@@ -29,9 +28,6 @@ public class WriteHandler {
     private final State state;
     private final LeaderWriteHandler leaderWrite;
     private final FollowerWriteHandler followerWrite;
-
-    private final AtomicInteger leaderEpoch = new AtomicInteger();
-    private final AtomicInteger counter = new AtomicInteger();
 
     public WriteHandler(final Controller controller, final MessageStore messageStore, final CandidateInformationRegistry registry, final ServerClient client, final RegistryManager manager, final Vertx vertx) {
         this.controller = controller;
@@ -90,7 +86,7 @@ public class WriteHandler {
      */
     public Future<Void> initialProposalUpdate(final ClientMessage message) {
         log.traceEntry(() -> message);
-        final Zxid id = new Zxid(leaderEpoch.get(), counter.getAndIncrement());
+        final Zxid id = new Zxid(state.getLeaderEpoch(), state.getAndIncrementCounter());
         log.info(String.format("Adding proposal %s to history and broadcasting proposal", id));
         return log.traceExit(state.addProposal(new Proposal(message, id))
             .compose(v -> state.processStateUpdate(id))
@@ -115,16 +111,6 @@ public class WriteHandler {
     public boolean isLeader() {
         log.traceEntry();
         return log.traceExit(controller.getLabel().equals(LeadershipElectionHandler.LEADER_LABEL));
-    }
-
-    public int getLeaderEpoch() {
-        log.traceEntry();
-        return log.traceExit(leaderEpoch.get());
-    }
-
-    public int getCounter() {
-        log.traceEntry();
-        return log.traceExit(counter.get());
     }
 
     public State getState() {

--- a/zookeeper/src/main/java/io/julian/zookeeper/write/WriteHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/write/WriteHandler.java
@@ -3,7 +3,6 @@ package io.julian.zookeeper.write;
 import io.julian.server.api.client.RegistryManager;
 import io.julian.server.api.client.ServerClient;
 import io.julian.server.components.Controller;
-import io.julian.server.components.MessageStore;
 import io.julian.server.models.HTTPRequest;
 import io.julian.server.models.control.ClientMessage;
 import io.julian.server.models.coordination.CoordinationMessage;
@@ -15,7 +14,6 @@ import io.julian.zookeeper.models.Proposal;
 import io.julian.zookeeper.models.ShortenedExchange;
 import io.julian.zookeeper.models.Zxid;
 import io.vertx.core.Future;
-import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -29,9 +27,9 @@ public class WriteHandler {
     private final LeaderWriteHandler leaderWrite;
     private final FollowerWriteHandler followerWrite;
 
-    public WriteHandler(final Controller controller, final MessageStore messageStore, final CandidateInformationRegistry registry, final ServerClient client, final RegistryManager manager, final Vertx vertx) {
+    public WriteHandler(final Controller controller, final State state, final CandidateInformationRegistry registry, final ServerClient client, final RegistryManager manager) {
         this.controller = controller;
-        this.state = new State(vertx, messageStore);
+        this.state = state;
         this.leaderWrite = new LeaderWriteHandler(getMajority(registry), client, manager);
         this.followerWrite = new FollowerWriteHandler(registry, client);
     }

--- a/zookeeper/src/test/java/io/julian/zookeeper/AbstractServerBase.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/AbstractServerBase.java
@@ -4,6 +4,8 @@ import io.julian.server.api.client.RegistryManager;
 import io.julian.server.api.client.ServerClient;
 import io.julian.server.components.Configuration;
 import io.julian.server.models.control.ServerConfiguration;
+import io.julian.zookeeper.election.CandidateInformationRegistry;
+import io.julian.zookeeper.models.CandidateInformation;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -43,6 +45,15 @@ public abstract class AbstractServerBase {
 
     protected void tearDownServer(final TestContext context, final TestServerComponents components) {
         components.tearDownServer(context, vertx);
+    }
+
+    protected CandidateInformationRegistry createTestCandidateInformationRegistry(final boolean doesUpdateLeader) {
+        CandidateInformationRegistry registry = new CandidateInformationRegistry();
+        registry.addCandidateInformation(new CandidateInformation(DEFAULT_SEVER_CONFIG.getHost(), DEFAULT_SEVER_CONFIG.getPort(), 1));
+        if (doesUpdateLeader) {
+            registry.updateNextLeader();
+        }
+        return registry;
     }
 
     protected RegistryManager createTestRegistryManager() {

--- a/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
@@ -46,9 +46,11 @@ public class IntegrationTest extends AbstractServerBase {
         TestClient client = createTestClient();
         Async async = context.async();
         client.POST_MESSAGE(leader.configuration.getHost(), leader.configuration.getPort(), MESSAGE)
-            .onComplete(v -> vertx.setTimer(3000, v2 -> {
-                Assert.assertEquals(1, server1.server.getMessages().getNumberOfMessages());
-                Assert.assertEquals(1, server2.server.getMessages().getNumberOfMessages());
+            .onComplete(v -> client.POST_MESSAGE(leader.configuration.getHost(), leader.configuration.getPort(), MESSAGE))
+            .onComplete(v -> client.POST_MESSAGE(leader.configuration.getHost(), leader.configuration.getPort(), MESSAGE))
+            .onComplete(v -> vertx.setTimer(4000, v2 -> {
+                Assert.assertEquals(3, server1.server.getMessages().getNumberOfMessages());
+                Assert.assertEquals(3, server2.server.getMessages().getNumberOfMessages());
                 async.complete();
             }));
         async.awaitSuccess();

--- a/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
@@ -46,7 +46,7 @@ public class IntegrationTest extends AbstractServerBase {
         TestClient client = createTestClient();
         Async async = context.async();
         client.POST_MESSAGE(leader.configuration.getHost(), leader.configuration.getPort(), MESSAGE)
-            .onComplete(v -> vertx.setTimer(1500, v2 -> {
+            .onComplete(v -> vertx.setTimer(3000, v2 -> {
                 Assert.assertEquals(1, server1.server.getMessages().getNumberOfMessages());
                 Assert.assertEquals(1, server2.server.getMessages().getNumberOfMessages());
                 async.complete();

--- a/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
@@ -46,11 +46,9 @@ public class IntegrationTest extends AbstractServerBase {
         TestClient client = createTestClient();
         Async async = context.async();
         client.POST_MESSAGE(leader.configuration.getHost(), leader.configuration.getPort(), MESSAGE)
-            .onComplete(v -> client.POST_MESSAGE(leader.configuration.getHost(), leader.configuration.getPort(), MESSAGE))
-            .onComplete(v -> client.POST_MESSAGE(leader.configuration.getHost(), leader.configuration.getPort(), MESSAGE))
             .onComplete(v -> vertx.setTimer(4000, v2 -> {
-                Assert.assertEquals(3, server1.server.getMessages().getNumberOfMessages());
-                Assert.assertEquals(3, server2.server.getMessages().getNumberOfMessages());
+                Assert.assertEquals(1, server1.server.getMessages().getNumberOfMessages());
+                Assert.assertEquals(1, server2.server.getMessages().getNumberOfMessages());
                 async.complete();
             }));
         async.awaitSuccess();

--- a/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
@@ -1,5 +1,6 @@
 package io.julian.zookeeper;
 
+import io.julian.ZookeeperAlgorithm;
 import io.julian.server.api.client.ServerClient;
 import io.julian.server.models.HTTPRequest;
 import io.julian.server.models.control.ServerConfiguration;
@@ -23,12 +24,26 @@ public class IntegrationTest extends AbstractServerBase {
         TestServerComponents server2 = setUpZookeeperApiServer(context, SECOND_SERVER_CONFIG);
         registerConfigurationInServer(server1, SECOND_SERVER_CONFIG);
         registerConfigurationInServer(server2, DEFAULT_SEVER_CONFIG);
+        int epoch = 3;
+        int counter = 6;
+        ZookeeperAlgorithm algorithm1 = (ZookeeperAlgorithm) server2.server.getVerticle().getAlgorithm();
+        algorithm1.getState().setLeaderEpoch(epoch);
+        algorithm1.getState().setCounter(counter);
+
         sendElectionMessage(context);
         List<String> labels = Arrays.asList(server2.server.getController().getLabel(), server1.server.getController().getLabel());
         Assert.assertEquals(1,
             labels.stream().filter(label -> label.equals(LeadershipElectionHandler.LEADER_LABEL)).count());
         Assert.assertEquals(1,
             labels.stream().filter(label -> label.equals(LeadershipElectionHandler.FOLLOWER_LABEL)).count());
+
+        Arrays.asList(server2, server1)
+            .forEach(server -> {
+                ZookeeperAlgorithm algorithm = (ZookeeperAlgorithm) server.server.getVerticle().getAlgorithm();
+                Assert.assertEquals(epoch, algorithm.getState().getLeaderEpoch());
+                Assert.assertEquals(epoch, algorithm.getState().getLeaderEpoch());
+            });
+
         tearDownServer(context, server1);
         tearDownServer(context, server2);
     }

--- a/zookeeper/src/test/java/io/julian/zookeeper/ZookeeperAlgorithmTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/ZookeeperAlgorithmTest.java
@@ -9,6 +9,7 @@ import io.julian.server.models.coordination.CoordinationMetadata;
 import io.julian.zookeeper.election.CandidateInformationRegistry;
 import io.julian.zookeeper.models.CandidateInformation;
 import io.julian.zookeeper.models.ShortenedExchange;
+import io.julian.zookeeper.models.Zxid;
 import io.vertx.core.Vertx;
 import org.junit.Assert;
 import org.junit.Before;
@@ -24,6 +25,7 @@ public class ZookeeperAlgorithmTest {
         map.put("test", Object.class);
         map.put("candidate_information", CandidateInformation.class);
         map.put("state_update", ShortenedExchange.class);
+        map.put("discovery", Zxid.class);
     }
 
     @Test

--- a/zookeeper/src/test/java/io/julian/zookeeper/controller/StateTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/controller/StateTest.java
@@ -35,6 +35,30 @@ public class StateTest {
     }
 
     @Test
+    public void TestInit() {
+        State state = new State(vertx, new MessageStore());
+        Assert.assertEquals(0, state.getHistory().size());
+        Assert.assertEquals(0, state.getCounter());
+        Assert.assertEquals(0, state.getLastAcceptedIndex());
+        Assert.assertEquals(0, state.getLeaderEpoch());
+        Assert.assertEquals(0, state.getMessageStore().getNumberOfMessages());
+    }
+
+    @Test
+    public void TestGetterAndSetter() {
+        State state = new State(vertx, new MessageStore());
+        int leaderEpoch = 15;
+        int counter = 1234;
+        state.setLeaderEpoch(leaderEpoch);
+        state.setCounter(counter);
+
+        Assert.assertEquals(leaderEpoch, state.getLeaderEpoch());
+        Assert.assertEquals(counter, state.getAndIncrementCounter());
+        Assert.assertEquals(counter + 1, state.getCounter());
+        Assert.assertEquals(counter + 1, state.getCounter());
+    }
+
+    @Test
     public void TestAddProposalCompletesSuccessfully(final TestContext context) {
         State state = new State(vertx, new MessageStore());
 
@@ -52,10 +76,10 @@ public class StateTest {
         int higher = 2;
         int lower = 1;
         state.setLastAcceptedIndex(higher);
-        Assert.assertEquals(higher, state.getLastAcceptedIndex());
+        Assert.assertEquals(higher + 1, state.getLastAcceptedIndex());
 
         state.setLastAcceptedIndex(lower);
-        Assert.assertEquals(higher, state.getLastAcceptedIndex());
+        Assert.assertEquals(higher + 1, state.getLastAcceptedIndex());
     }
 
     @Test

--- a/zookeeper/src/test/java/io/julian/zookeeper/discovery/DiscoveryHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/discovery/DiscoveryHandlerTest.java
@@ -1,0 +1,120 @@
+package io.julian.zookeeper.discovery;
+
+import io.julian.server.api.client.RegistryManager;
+import io.julian.server.components.Configuration;
+import io.julian.server.components.Controller;
+import io.julian.server.components.MessageStore;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.control.ServerConfiguration;
+import io.julian.server.models.coordination.CoordinationMessage;
+import io.julian.server.models.coordination.CoordinationMetadata;
+import io.julian.zookeeper.AbstractServerBase;
+import io.julian.zookeeper.TestServerComponents;
+import io.julian.zookeeper.controller.State;
+import io.julian.zookeeper.election.CandidateInformationRegistry;
+import io.julian.zookeeper.election.LeadershipElectionHandler;
+import io.julian.zookeeper.models.Zxid;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DiscoveryHandlerTest extends AbstractServerBase {
+    private final static int EPOCH = 12;
+    private final static int COUNTER = 2512;
+    private final static Zxid ID = new Zxid(EPOCH, COUNTER);
+
+    @Test
+    public void TestResetAsFollower() {
+        DiscoveryHandler handler = createDiscoveryHandler(true);
+        handler.getState().setCounter(1);
+        handler.getState().setLeaderEpoch(2);
+        Assert.assertFalse(handler.hasBroadcastFollowerZXID());
+        Assert.assertEquals(0, handler.getLeaderHandler().getCounter());
+        Assert.assertEquals(0, handler.getLeaderHandler().getEpoch());
+
+        handler.reset();
+        Assert.assertTrue(handler.hasBroadcastFollowerZXID());
+        Assert.assertEquals(1, handler.getLeaderHandler().getCounter());
+        Assert.assertEquals(2, handler.getLeaderHandler().getEpoch());
+    }
+
+    @Test
+    public void TestBroadcastToFollowersSucceeds(final TestContext context) {
+        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        DiscoveryHandler handler = createDiscoveryHandler(false);
+
+        Async async = context.async();
+        handler.broadcastToFollowers()
+            .onComplete(context.asyncAssertSuccess(res -> {
+                context.assertTrue(handler.hasBroadcastFollowerZXID());
+                async.complete();
+            }));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+    }
+
+    @Test
+    public void TestHandleCoordinationMessageAsFollower(final TestContext context) {
+        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        DiscoveryHandler handler = createDiscoveryHandler(true);
+
+        Async async = context.async();
+        handler.handleCoordinationMessage(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN), null, null))
+            .onComplete(context.asyncAssertSuccess(res -> async.complete()));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+    }
+
+    @Test
+    public void TestHandleCoordinationMessageAsLeaderFails(final TestContext context) {
+        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        DiscoveryHandler handler = createDiscoveryHandler(false, SECOND_SERVER_CONFIG);
+
+        Async async = context.async();
+        handler.handleCoordinationMessage(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN), null, ID.toJson()))
+            .onComplete(context.asyncAssertFailure(cause -> {
+                Assert.assertEquals(DiscoveryHandler.NOT_ENOUGH_RESPONSES_ERROR, cause.getMessage());
+                async.complete();
+            }));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+    }
+
+    @Test
+    public void TestHandleCoordinationMessageAsLeaderSucceeds(final TestContext context) {
+        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        DiscoveryHandler handler = createDiscoveryHandler(false);
+
+        Async async = context.async();
+        handler.handleCoordinationMessage(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN), null, ID.toJson()))
+            .onComplete(context.asyncAssertSuccess(cause -> async.complete()));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+    }
+
+    @Test
+    public void TestResetAsLeader() {
+        DiscoveryHandler handler = createDiscoveryHandler(false);
+        handler.getState().setCounter(1);
+        handler.getState().setLeaderEpoch(2);
+        Assert.assertFalse(handler.hasBroadcastFollowerZXID());
+        Assert.assertEquals(0, handler.getLeaderHandler().getCounter());
+        Assert.assertEquals(0, handler.getLeaderHandler().getEpoch());
+
+        handler.reset();
+        Assert.assertFalse(handler.hasBroadcastFollowerZXID());
+        Assert.assertEquals(1, handler.getLeaderHandler().getCounter());
+        Assert.assertEquals(2, handler.getLeaderHandler().getEpoch());
+    }
+
+    private DiscoveryHandler createDiscoveryHandler(final boolean isFollower, final ServerConfiguration... configurations) {
+        CandidateInformationRegistry candidateInformationRegistry = createTestCandidateInformationRegistry(isFollower);
+        Controller controller = new Controller(new Configuration());
+        controller.setLabel(isFollower ? LeadershipElectionHandler.FOLLOWER_LABEL : LeadershipElectionHandler.LEADER_LABEL);
+
+        RegistryManager manager = createTestRegistryManager();
+        for (ServerConfiguration configuration : configurations) manager.registerServer(configuration.getHost(), configuration.getPort());
+        return new DiscoveryHandler(controller, new State(vertx, new MessageStore()), candidateInformationRegistry, manager, createServerClient());
+    }
+}

--- a/zookeeper/src/test/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandlerTest.java
@@ -24,7 +24,7 @@ public class FollowerDiscoveryHandlerTest extends AbstractServerBase {
         FollowerDiscoveryHandler handler = getTestHandler(registry);
         CoordinationMessage message = handler.createCoordinationMessage(ID);
         Assert.assertEquals(HTTPRequest.UNKNOWN, message.getMetadata().getRequest());
-        Assert.assertEquals(FollowerDiscoveryHandler.ZXID_FOLLOWER_TYPE, message.getMetadata().getType());
+        Assert.assertEquals(DiscoveryHandler.DISCOVERY_TYPE, message.getMetadata().getType());
         Assert.assertNull(message.getMessage());
         Assert.assertEquals(ID.toJson().encodePrettily(), message.getDefinition().encodePrettily());
     }
@@ -54,6 +54,20 @@ public class FollowerDiscoveryHandlerTest extends AbstractServerBase {
                 async.complete();
             }));
         async.awaitSuccess();
+    }
+
+    @Test
+    public void TestUpdateToLeaderState() {
+        CandidateInformationRegistry registry = createTestCandidateInformationRegistry(true);
+        FollowerDiscoveryHandler handler = getTestHandler(registry);
+        Assert.assertEquals(0, handler.getState().getLeaderEpoch());
+        Assert.assertEquals(0, handler.getState().getCounter());
+
+        int leaderEpoch = -1;
+        int counter = 3;
+        handler.updateToLeaderState(new Zxid(leaderEpoch, counter));
+        Assert.assertEquals(leaderEpoch, handler.getState().getLeaderEpoch());
+        Assert.assertEquals(counter, handler.getState().getCounter());
     }
 
     private FollowerDiscoveryHandler getTestHandler(final CandidateInformationRegistry registry) {

--- a/zookeeper/src/test/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandlerTest.java
@@ -1,0 +1,62 @@
+package io.julian.zookeeper.discovery;
+
+import io.julian.server.components.MessageStore;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.coordination.CoordinationMessage;
+import io.julian.zookeeper.AbstractServerBase;
+import io.julian.zookeeper.TestServerComponents;
+import io.julian.zookeeper.controller.State;
+import io.julian.zookeeper.election.CandidateInformationRegistry;
+import io.julian.zookeeper.models.Zxid;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FollowerDiscoveryHandlerTest extends AbstractServerBase {
+    private final static int EPOCH = 12;
+    private final static int COUNTER = 4321;
+    private final static Zxid ID = new Zxid(EPOCH, COUNTER);
+
+    @Test
+    public void TestCreateCoordinationMessage() {
+        CandidateInformationRegistry registry = createTestCandidateInformationRegistry(false);
+        FollowerDiscoveryHandler handler = getTestHandler(registry);
+        CoordinationMessage message = handler.createCoordinationMessage(ID);
+        Assert.assertEquals(HTTPRequest.UNKNOWN, message.getMetadata().getRequest());
+        Assert.assertEquals(FollowerDiscoveryHandler.ZXID_FOLLOWER_TYPE, message.getMetadata().getType());
+        Assert.assertNull(message.getMessage());
+        Assert.assertEquals(ID.toJson().encodePrettily(), message.getDefinition().encodePrettily());
+    }
+
+    @Test
+    public void TestReplyToLeaderIsSuccessful(final TestContext context) {
+        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        CandidateInformationRegistry registry = createTestCandidateInformationRegistry(true);
+        FollowerDiscoveryHandler handler = getTestHandler(registry);
+
+        Async async = context.async();
+        handler.replyToLeader()
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+    }
+
+    @Test
+    public void TestReplyToLeaderFails(final TestContext context) {
+        CandidateInformationRegistry registry = createTestCandidateInformationRegistry(true);
+        FollowerDiscoveryHandler handler = getTestHandler(registry);
+
+        Async async = context.async();
+        handler.replyToLeader()
+            .onComplete(context.asyncAssertFailure(cause -> {
+                context.assertEquals(CONNECTION_REFUSED_EXCEPTION, cause.getMessage());
+                async.complete();
+            }));
+        async.awaitSuccess();
+    }
+
+    private FollowerDiscoveryHandler getTestHandler(final CandidateInformationRegistry registry) {
+        return new FollowerDiscoveryHandler(new State(vertx, new MessageStore()), registry, createServerClient());
+    }
+}

--- a/zookeeper/src/test/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandlerTest.java
@@ -1,9 +1,14 @@
 package io.julian.zookeeper.discovery;
 
 import io.julian.server.components.MessageStore;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.coordination.CoordinationMessage;
 import io.julian.zookeeper.AbstractServerBase;
+import io.julian.zookeeper.TestServerComponents;
 import io.julian.zookeeper.controller.State;
 import io.julian.zookeeper.models.Zxid;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -73,6 +78,41 @@ public class LeaderDiscoveryHandlerTest extends AbstractServerBase {
         Assert.assertEquals(handler.getState().getLeaderEpoch(), handler.getEpoch());
         Assert.assertEquals(handler.getState().getCounter(), handler.getCounter());
         Assert.assertEquals(0, handler.getFollowerResponses());
+    }
+
+    @Test
+    public void TestBroadcastGatherZXIDSucceeds(final TestContext context) {
+        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        LeaderDiscoveryHandler handler = createHandler();
+        Async async = context.async();
+        handler.broadcastGatherZXID()
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+    }
+
+    @Test
+    public void TestBroadcastGatherZXIDFails(final TestContext context) {
+        LeaderDiscoveryHandler handler = createHandler();
+        Async async = context.async();
+        handler.broadcastGatherZXID()
+            .onComplete(context.asyncAssertFailure(cause -> {
+                Assert.assertEquals(CONNECTION_REFUSED_EXCEPTION, cause.getMessage());
+                async.complete();
+            }));
+        async.awaitSuccess();
+    }
+
+    @Test
+    public void TestCreateBroadcastMessage() {
+        LeaderDiscoveryHandler handler = createHandler();
+        String type = "random-type";
+        CoordinationMessage message = handler.createBroadcastMessage(type);
+        Assert.assertEquals(type, message.getMetadata().getType());
+        Assert.assertEquals(HTTPRequest.UNKNOWN, message.getMetadata().getRequest());
+        Assert.assertNull(message.getMessage());
+        Assert.assertNull(message.getDefinition());
+        Assert.assertNotNull(message.toJson().encodePrettily());
     }
 
     private LeaderDiscoveryHandler createHandler() {

--- a/zookeeper/src/test/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandlerTest.java
@@ -26,19 +26,19 @@ public class LeaderDiscoveryHandlerTest extends AbstractServerBase {
     }
 
     @Test
-    public void TestProcessFollowerEpoch() {
+    public void TestProcessFollowerZXID() {
         LeaderDiscoveryHandler handler = createHandler();
-        handler.processFollowerEpoch(LOWER_ID);
+        handler.processFollowerZXID(LOWER_ID);
         Assert.assertEquals(LOWER_ID.getEpoch(), handler.getEpoch());
         Assert.assertEquals(LOWER_ID.getCounter(), handler.getCounter());
         Assert.assertEquals(1, handler.getFollowerResponses());
 
-        handler.processFollowerEpoch(HIGHER_ID);
+        handler.processFollowerZXID(HIGHER_ID);
         Assert.assertEquals(HIGHER_ID.getEpoch(), handler.getEpoch());
         Assert.assertEquals(HIGHER_ID.getCounter(), handler.getCounter());
         Assert.assertEquals(2, handler.getFollowerResponses());
 
-        handler.processFollowerEpoch(MIDDLE_ID);
+        handler.processFollowerZXID(MIDDLE_ID);
         Assert.assertEquals(HIGHER_ID.getEpoch(), handler.getEpoch());
         Assert.assertEquals(HIGHER_ID.getCounter(), handler.getCounter());
         Assert.assertEquals(3, handler.getFollowerResponses());
@@ -49,7 +49,7 @@ public class LeaderDiscoveryHandlerTest extends AbstractServerBase {
         LeaderDiscoveryHandler handler = createHandler();
         Assert.assertFalse(handler.hasEnoughResponses());
 
-        handler.processFollowerEpoch(LOWER_ID);
+        handler.processFollowerZXID(LOWER_ID);
         Assert.assertTrue(handler.hasEnoughResponses());
     }
 
@@ -58,7 +58,7 @@ public class LeaderDiscoveryHandlerTest extends AbstractServerBase {
         LeaderDiscoveryHandler handler = createHandler();
         Assert.assertEquals(0, handler.getState().getCounter());
         Assert.assertEquals(0, handler.getState().getLeaderEpoch());
-        handler.processFollowerEpoch(LOWER_ID);
+        handler.processFollowerZXID(LOWER_ID);
         handler.updateStateEpochAndCounter();
 
         Assert.assertEquals(LOWER_ID.getCounter(), handler.getState().getCounter());
@@ -68,8 +68,8 @@ public class LeaderDiscoveryHandlerTest extends AbstractServerBase {
     @Test
     public void TestReset() {
         LeaderDiscoveryHandler handler = createHandler();
-        handler.processFollowerEpoch(LOWER_ID);
-        handler.processFollowerEpoch(HIGHER_ID);
+        handler.processFollowerZXID(LOWER_ID);
+        handler.processFollowerZXID(HIGHER_ID);
         Assert.assertEquals(HIGHER_ID.getEpoch(), handler.getEpoch());
         Assert.assertEquals(HIGHER_ID.getCounter(), handler.getCounter());
         Assert.assertEquals(2, handler.getFollowerResponses());
@@ -116,6 +116,6 @@ public class LeaderDiscoveryHandlerTest extends AbstractServerBase {
     }
 
     private LeaderDiscoveryHandler createHandler() {
-        return new LeaderDiscoveryHandler(new State(vertx, new MessageStore()), createServerClient(), createTestRegistryManager());
+        return new LeaderDiscoveryHandler(new State(vertx, new MessageStore()), createTestRegistryManager(), createServerClient());
     }
 }

--- a/zookeeper/src/test/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandlerTest.java
@@ -1,0 +1,81 @@
+package io.julian.zookeeper.discovery;
+
+import io.julian.server.components.MessageStore;
+import io.julian.zookeeper.AbstractServerBase;
+import io.julian.zookeeper.controller.State;
+import io.julian.zookeeper.models.Zxid;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LeaderDiscoveryHandlerTest extends AbstractServerBase {
+    private final static Zxid LOWER_ID = new Zxid(1, 1);
+    private final static Zxid MIDDLE_ID = new Zxid(1, 5);
+    private final static Zxid HIGHER_ID = new Zxid(2, 3);
+
+    @Test
+    public void TestInit() {
+        LeaderDiscoveryHandler handler = createHandler();
+        Assert.assertEquals(0, handler.getEpoch());
+        Assert.assertEquals(0, handler.getFollowerResponses());
+        Assert.assertFalse(handler.hasEnoughResponses());
+    }
+
+    @Test
+    public void TestProcessFollowerEpoch() {
+        LeaderDiscoveryHandler handler = createHandler();
+        handler.processFollowerEpoch(LOWER_ID);
+        Assert.assertEquals(LOWER_ID.getEpoch(), handler.getEpoch());
+        Assert.assertEquals(LOWER_ID.getCounter(), handler.getCounter());
+        Assert.assertEquals(1, handler.getFollowerResponses());
+
+        handler.processFollowerEpoch(HIGHER_ID);
+        Assert.assertEquals(HIGHER_ID.getEpoch(), handler.getEpoch());
+        Assert.assertEquals(HIGHER_ID.getCounter(), handler.getCounter());
+        Assert.assertEquals(2, handler.getFollowerResponses());
+
+        handler.processFollowerEpoch(MIDDLE_ID);
+        Assert.assertEquals(HIGHER_ID.getEpoch(), handler.getEpoch());
+        Assert.assertEquals(HIGHER_ID.getCounter(), handler.getCounter());
+        Assert.assertEquals(3, handler.getFollowerResponses());
+    }
+
+    @Test
+    public void TestHasEnoughResponses() {
+        LeaderDiscoveryHandler handler = createHandler();
+        Assert.assertFalse(handler.hasEnoughResponses());
+
+        handler.processFollowerEpoch(LOWER_ID);
+        Assert.assertTrue(handler.hasEnoughResponses());
+    }
+
+    @Test
+    public void TestUpdateStateEpochAndCounter() {
+        LeaderDiscoveryHandler handler = createHandler();
+        Assert.assertEquals(0, handler.getState().getCounter());
+        Assert.assertEquals(0, handler.getState().getLeaderEpoch());
+        handler.processFollowerEpoch(LOWER_ID);
+        handler.updateStateEpochAndCounter();
+
+        Assert.assertEquals(LOWER_ID.getCounter(), handler.getState().getCounter());
+        Assert.assertEquals(LOWER_ID.getEpoch(), handler.getState().getLeaderEpoch());
+    }
+
+    @Test
+    public void TestReset() {
+        LeaderDiscoveryHandler handler = createHandler();
+        handler.processFollowerEpoch(LOWER_ID);
+        handler.processFollowerEpoch(HIGHER_ID);
+        Assert.assertEquals(HIGHER_ID.getEpoch(), handler.getEpoch());
+        Assert.assertEquals(HIGHER_ID.getCounter(), handler.getCounter());
+        Assert.assertEquals(2, handler.getFollowerResponses());
+
+        handler.reset();
+        Assert.assertEquals(handler.getState().getLeaderEpoch(), handler.getEpoch());
+        Assert.assertEquals(handler.getState().getCounter(), handler.getCounter());
+        Assert.assertEquals(0, handler.getFollowerResponses());
+    }
+
+    private LeaderDiscoveryHandler createHandler() {
+        return new LeaderDiscoveryHandler(new State(vertx, new MessageStore()), createServerClient(), createTestRegistryManager());
+    }
+}

--- a/zookeeper/src/test/java/io/julian/zookeeper/write/FollowerWriterHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/write/FollowerWriterHandlerTest.java
@@ -1,14 +1,11 @@
 package io.julian.zookeeper.write;
 
-import io.julian.server.components.Configuration;
 import io.julian.server.models.HTTPRequest;
 import io.julian.server.models.control.ClientMessage;
 import io.julian.server.models.coordination.CoordinationMessage;
 import io.julian.zookeeper.AbstractServerBase;
 import io.julian.zookeeper.TestServerComponents;
-import io.julian.zookeeper.election.CandidateInformationRegistry;
 import io.julian.zookeeper.election.LeadershipElectionHandler;
-import io.julian.zookeeper.models.CandidateInformation;
 import io.julian.zookeeper.models.MessagePhase;
 import io.julian.zookeeper.models.ShortenedExchange;
 import io.julian.zookeeper.models.Zxid;
@@ -119,14 +116,7 @@ public class FollowerWriterHandlerTest extends AbstractServerBase {
             .getJsonObject(ShortenedExchange.TRANSACTIONAL_ID_KEY).getInteger(Zxid.EPOCH_KEY).intValue());
     }
 
-    private CandidateInformationRegistry createCandidateRegistry() {
-        CandidateInformationRegistry registry = new CandidateInformationRegistry();
-        registry.addCandidateInformation(new CandidateInformation(Configuration.DEFAULT_SERVER_HOST, Configuration.DEFAULT_SERVER_PORT, 1));
-        registry.updateNextLeader();
-        return registry;
-    }
-
     private FollowerWriteHandler createFollowerWriteHandler() {
-        return new FollowerWriteHandler(createCandidateRegistry(), createServerClient());
+        return new FollowerWriteHandler(createTestCandidateInformationRegistry(true), createServerClient());
     }
 }

--- a/zookeeper/src/test/java/io/julian/zookeeper/write/WriteHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/write/WriteHandlerTest.java
@@ -31,8 +31,8 @@ public class WriteHandlerTest extends AbstractServerBase {
     @Test
     public void TestInitialization() {
         WriteHandler write = createWriteHandler();
-        Assert.assertEquals(0, write.getCounter());
-        Assert.assertEquals(0, write.getLeaderEpoch());
+        Assert.assertEquals(0, write.getState().getCounter());
+        Assert.assertEquals(0, write.getState().getLeaderEpoch());
         Assert.assertEquals(0, write.getState().getHistory().size());
         Assert.assertNotNull(write.getProposalTracker());
     }
@@ -49,8 +49,8 @@ public class WriteHandlerTest extends AbstractServerBase {
                 context.assertEquals(1, handler.getProposalTracker().getAcknowledgedProposals().size());
                 context.assertEquals(0, handler.getProposalTracker().getCommittedProposals().size());
                 context.assertEquals(1, handler.getState().getMessageStore().getNumberOfMessages());
-                context.assertEquals(0, handler.getLeaderEpoch());
-                context.assertEquals(1, handler.getCounter());
+                context.assertEquals(0, handler.getState().getLeaderEpoch());
+                context.assertEquals(1, handler.getState().getCounter());
                 async.complete();
             }));
 
@@ -69,8 +69,8 @@ public class WriteHandlerTest extends AbstractServerBase {
                 context.assertEquals(1, handler.getState().getHistory().size());
                 context.assertEquals(0, handler.getProposalTracker().getAcknowledgedProposals().size());
                 context.assertEquals(0, handler.getProposalTracker().getCommittedProposals().size());
-                context.assertEquals(0, handler.getLeaderEpoch());
-                context.assertEquals(1, handler.getCounter());
+                context.assertEquals(0, handler.getState().getLeaderEpoch());
+                context.assertEquals(1, handler.getState().getCounter());
                 async.complete();
             }));
 
@@ -95,8 +95,8 @@ public class WriteHandlerTest extends AbstractServerBase {
                 context.assertEquals(0, handler.getState().getHistory().size());
                 context.assertEquals(1, handler.getProposalTracker().getAcknowledgedProposals().size());
                 context.assertEquals(0, handler.getProposalTracker().getCommittedProposals().size());
-                context.assertEquals(0, handler.getLeaderEpoch());
-                context.assertEquals(0, handler.getCounter());
+                context.assertEquals(0, handler.getState().getLeaderEpoch());
+                context.assertEquals(0, handler.getState().getCounter());
                 async.complete();
             }));
 
@@ -119,8 +119,8 @@ public class WriteHandlerTest extends AbstractServerBase {
                 context.assertEquals(0, handler.getState().getHistory().size());
                 context.assertEquals(0, handler.getProposalTracker().getAcknowledgedProposals().size());
                 context.assertEquals(1, handler.getProposalTracker().getCommittedProposals().size());
-                context.assertEquals(0, handler.getLeaderEpoch());
-                context.assertEquals(0, handler.getCounter());
+                context.assertEquals(0, handler.getState().getLeaderEpoch());
+                context.assertEquals(0, handler.getState().getCounter());
                 async.complete();
             }));
 
@@ -173,8 +173,8 @@ public class WriteHandlerTest extends AbstractServerBase {
                 context.assertEquals(1, handler.getProposalTracker().getAcknowledgedProposals().size());
                 context.assertEquals(0, handler.getProposalTracker().getCommittedProposals().size());
                 context.assertEquals(1, handler.getState().getMessageStore().getNumberOfMessages());
-                context.assertEquals(0, handler.getLeaderEpoch());
-                context.assertEquals(1, handler.getCounter());
+                context.assertEquals(0, handler.getState().getLeaderEpoch());
+                context.assertEquals(1, handler.getState().getCounter());
                 async.complete();
             }));
 
@@ -195,8 +195,8 @@ public class WriteHandlerTest extends AbstractServerBase {
                 context.assertEquals(0, handler.getProposalTracker().getAcknowledgedProposals().size());
                 context.assertEquals(0, handler.getProposalTracker().getCommittedProposals().size());
                 context.assertEquals(0, handler.getState().getMessageStore().getNumberOfMessages());
-                context.assertEquals(0, handler.getLeaderEpoch());
-                context.assertEquals(0, handler.getCounter());
+                context.assertEquals(0, handler.getState().getLeaderEpoch());
+                context.assertEquals(0, handler.getState().getCounter());
                 async.complete();
             }));
 
@@ -217,8 +217,8 @@ public class WriteHandlerTest extends AbstractServerBase {
                 context.assertEquals(0, handler.getProposalTracker().getAcknowledgedProposals().size());
                 context.assertEquals(0, handler.getProposalTracker().getCommittedProposals().size());
                 context.assertEquals(0, handler.getState().getMessageStore().getNumberOfMessages());
-                context.assertEquals(0, handler.getLeaderEpoch());
-                context.assertEquals(0, handler.getCounter());
+                context.assertEquals(0, handler.getState().getLeaderEpoch());
+                context.assertEquals(0, handler.getState().getCounter());
                 async.complete();
             }));
 
@@ -238,8 +238,8 @@ public class WriteHandlerTest extends AbstractServerBase {
                 context.assertEquals(0, handler.getProposalTracker().getAcknowledgedProposals().size());
                 context.assertEquals(0, handler.getProposalTracker().getCommittedProposals().size());
                 context.assertEquals(0, handler.getState().getMessageStore().getNumberOfMessages());
-                context.assertEquals(0, handler.getLeaderEpoch());
-                context.assertEquals(0, handler.getCounter());
+                context.assertEquals(0, handler.getState().getLeaderEpoch());
+                context.assertEquals(0, handler.getState().getCounter());
                 async.complete();
             }));
 

--- a/zookeeper/src/test/java/io/julian/zookeeper/write/WriteHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/write/WriteHandlerTest.java
@@ -82,7 +82,7 @@ public class WriteHandlerTest extends AbstractServerBase {
         TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
         TestServerComponents server2 = setUpBasicApiServer(context, SECOND_SERVER_CONFIG);
 
-        CandidateInformationRegistry registry = createTestCandidateInformationRegistry();
+        CandidateInformationRegistry registry = createTestCandidateInformationRegistry(false);
         registry.addCandidateInformation(new CandidateInformation(SECOND_SERVER_CONFIG.getHost(), SECOND_SERVER_CONFIG.getPort(), 1234));
 
         WriteHandler handler = createWriteHandler(registry);
@@ -131,7 +131,7 @@ public class WriteHandlerTest extends AbstractServerBase {
     @Test
     public void TestAcknowledgeLeaderWhenAck(final TestContext context) {
         TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
-        WriteHandler handler = createWriteHandler(createTestCandidateInformationRegistry());
+        WriteHandler handler = createWriteHandler(createTestCandidateInformationRegistry(true));
 
         Async async = context.async();
         handler.acknowledgeLeader(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN), POST_MESSAGE.toJson(), new ShortenedExchange(MessagePhase.ACK, ID).toJson()))
@@ -147,7 +147,7 @@ public class WriteHandlerTest extends AbstractServerBase {
     @Test
     public void TestAcknowledgeLeaderWhenCommit(final TestContext context) {
         TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
-        WriteHandler handler = createWriteHandler(createTestCandidateInformationRegistry());
+        WriteHandler handler = createWriteHandler(createTestCandidateInformationRegistry(false));
         handler.getState().addProposal(new Proposal(POST_MESSAGE, ID));
         Async async = context.async();
         handler.acknowledgeLeader(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN), POST_MESSAGE.toJson(), new ShortenedExchange(MessagePhase.COMMIT, ID).toJson()))
@@ -163,7 +163,7 @@ public class WriteHandlerTest extends AbstractServerBase {
     @Test
     public void TestHandleCoordinationMessageAsLeaderBroadcastsUpdate(final TestContext context) {
         TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
-        WriteHandler handler = createWriteHandler(createTestCandidateInformationRegistry());
+        WriteHandler handler = createWriteHandler(createTestCandidateInformationRegistry(false));
         handler.getController().setLabel(LeadershipElectionHandler.LEADER_LABEL);
 
         Async async = context.async();
@@ -185,7 +185,7 @@ public class WriteHandlerTest extends AbstractServerBase {
     @Test
     public void TestHandleCoordinationMessageAsLeaderBroadcastsCommit(final TestContext context) {
         TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
-        WriteHandler handler = createWriteHandler(createTestCandidateInformationRegistry());
+        WriteHandler handler = createWriteHandler(createTestCandidateInformationRegistry(false));
         handler.getController().setLabel(LeadershipElectionHandler.LEADER_LABEL);
 
         Async async = context.async();
@@ -207,7 +207,7 @@ public class WriteHandlerTest extends AbstractServerBase {
     @Test
     public void TestHandleCoordinationMessageAsFollowerBroadcastsCommit(final TestContext context) {
         TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
-        WriteHandler handler = createWriteHandler(createTestCandidateInformationRegistry());
+        WriteHandler handler = createWriteHandler(createTestCandidateInformationRegistry(true));
         handler.getController().setLabel(LeadershipElectionHandler.FOLLOWER_LABEL);
 
         Async async = context.async();
@@ -229,7 +229,7 @@ public class WriteHandlerTest extends AbstractServerBase {
     @Test
     public void TestHandleClientMessageAsFollowerForwardsToLeader(final TestContext context) {
         TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
-        WriteHandler handler = createWriteHandler(createTestCandidateInformationRegistry());
+        WriteHandler handler = createWriteHandler(createTestCandidateInformationRegistry(true));
         handler.getController().setLabel(LeadershipElectionHandler.FOLLOWER_LABEL);
         Async async = context.async();
         handler.handleClientMessage(POST_MESSAGE)
@@ -247,18 +247,11 @@ public class WriteHandlerTest extends AbstractServerBase {
         tearDownServer(context, server);
     }
 
-    private CandidateInformationRegistry createTestCandidateInformationRegistry() {
-        CandidateInformationRegistry registry = new CandidateInformationRegistry();
-        registry.addCandidateInformation(new CandidateInformation(Configuration.DEFAULT_SERVER_HOST, Configuration.DEFAULT_SERVER_PORT, 1));
-        registry.updateNextLeader();
-        return registry;
-    }
-
     private WriteHandler createWriteHandler(final CandidateInformationRegistry candidateInformationRegistry) {
         return new WriteHandler(new Controller(new Configuration()), new MessageStore(), candidateInformationRegistry, createServerClient(), createTestRegistryManager(), vertx);
     }
 
     private WriteHandler createWriteHandler() {
-        return new WriteHandler(new Controller(new Configuration()), new MessageStore(), createTestCandidateInformationRegistry(), createServerClient(), createTestRegistryManager(), vertx);
+        return new WriteHandler(new Controller(new Configuration()), new MessageStore(), createTestCandidateInformationRegistry(false), createServerClient(), createTestRegistryManager(), vertx);
     }
 }

--- a/zookeeper/src/test/java/io/julian/zookeeper/write/WriteHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/write/WriteHandlerTest.java
@@ -9,6 +9,7 @@ import io.julian.server.models.coordination.CoordinationMessage;
 import io.julian.server.models.coordination.CoordinationMetadata;
 import io.julian.zookeeper.AbstractServerBase;
 import io.julian.zookeeper.TestServerComponents;
+import io.julian.zookeeper.controller.State;
 import io.julian.zookeeper.election.CandidateInformationRegistry;
 import io.julian.zookeeper.election.LeadershipElectionHandler;
 import io.julian.zookeeper.models.CandidateInformation;
@@ -248,10 +249,10 @@ public class WriteHandlerTest extends AbstractServerBase {
     }
 
     private WriteHandler createWriteHandler(final CandidateInformationRegistry candidateInformationRegistry) {
-        return new WriteHandler(new Controller(new Configuration()), new MessageStore(), candidateInformationRegistry, createServerClient(), createTestRegistryManager(), vertx);
+        return new WriteHandler(new Controller(new Configuration()), new State(vertx, new MessageStore()), candidateInformationRegistry, createServerClient(), createTestRegistryManager());
     }
 
     private WriteHandler createWriteHandler() {
-        return new WriteHandler(new Controller(new Configuration()), new MessageStore(), createTestCandidateInformationRegistry(false), createServerClient(), createTestRegistryManager(), vertx);
+        return createWriteHandler(createTestCandidateInformationRegistry(false));
     }
 }


### PR DESCRIPTION
Implemented the Zookeeper discovery phase in which the leader will retrieve all epochs and counters from the followers and reset the state to the latest epoch and counter. The leader will then broadcast the latest state to the followers.

Implemented all the unit tests as well and fixed a bug where the leader couldn't write more than one message.

Closes: #38

Signed-off-by: Julian Goh <juliangohsl@gmail.com>
