### PR TITLE
feat: Synchronize

### DIFF
--- a/zookeeper/src/main/java/io/julian/ZookeeperAlgorithm.java
+++ b/zookeeper/src/main/java/io/julian/ZookeeperAlgorithm.java
@@ -113,7 +113,7 @@ public class ZookeeperAlgorithm extends DistributedAlgorithm {
      */
     private void updateLeader() {
         log.traceEntry();
-        if (electionHandler.canUpdateLeader(registryManager) && controller.getLabel().equals("")) {
+        if (controller.getLabel().equals("") && electionHandler.canUpdateLeader(registryManager)) {
             log.info("Updating leader of servers");
             electionHandler.updateLeader(registryManager, controller);
             if (controller.getLabel().equals(LeadershipElectionHandler.LEADER_LABEL) && !this.discoveryHandler.hasBroadcastFollowerZXID()) {
@@ -121,8 +121,6 @@ public class ZookeeperAlgorithm extends DistributedAlgorithm {
                 this.discoveryHandler.reset();
                 this.discoveryHandler.broadcastToFollowers();
             }
-        } else {
-            log.info("Cannot update leader as not all candidate information have been received");
         }
         log.traceExit();
     }

--- a/zookeeper/src/main/java/io/julian/zookeeper/discovery/DiscoveryHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/discovery/DiscoveryHandler.java
@@ -81,4 +81,9 @@ public class DiscoveryHandler {
         log.traceEntry();
         return log.traceExit(leaderHandler);
     }
+
+    public boolean hasEnoughResponses() {
+        log.traceEntry();
+        return log.traceExit(leaderHandler.hasEnoughResponses());
+    }
 }

--- a/zookeeper/src/main/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandler.java
@@ -28,16 +28,15 @@ public class FollowerDiscoveryHandler {
 
     public Future<Void> replyToLeader() {
         log.traceEntry();
-        final Zxid id = new Zxid(state.getLeaderEpoch(), state.getCounter());
-        log.info(String.format("Sending leader latest ZXID %s", id));
+        log.info("Sending leader latest state");
         Promise<Void> post = Promise.promise();
-        client.sendCoordinateMessageToServer(registry.getLeaderServerConfiguration(), createCoordinationMessage(id))
+        client.sendCoordinateMessageToServer(registry.getLeaderServerConfiguration(), createCoordinationMessage())
             .onSuccess(v -> {
-                log.info(String.format("Successfully sent leader latest ZXID %s", id));
+                log.info("Successfully sent leader latest state");
                 post.complete();
             })
             .onFailure(cause -> {
-                log.info(String.format("Unsuccessfully sent leader latest ZXID %s", id));
+                log.info("Unsuccessfully sent leader latest state ZXID");
                 log.error(cause);
                 post.fail(cause);
             });
@@ -52,11 +51,11 @@ public class FollowerDiscoveryHandler {
         log.traceExit();
     }
 
-    public CoordinationMessage createCoordinationMessage(final Zxid id) {
-        log.traceEntry(() -> id);
+    public CoordinationMessage createCoordinationMessage() {
+        log.traceEntry();
         return log.traceExit(new CoordinationMessage(
             new CoordinationMetadata(HTTPRequest.UNKNOWN, "", DiscoveryHandler.DISCOVERY_TYPE),
             null,
-            id.toJson()));
+            state.toJson()));
     }
 }

--- a/zookeeper/src/main/java/io/julian/zookeeper/models/Zxid.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/models/Zxid.java
@@ -4,14 +4,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.json.JsonObject;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Objects;
 
 @Getter
 @Setter
 public class Zxid {
-    public final static String EPOCH_KEY = "epoch";
-    public final static String COUNTER_KEY = "counter";
+    private static final Logger log = LogManager.getLogger(Zxid.class);
+    public static final String EPOCH_KEY = "epoch";
+    public static final String COUNTER_KEY = "counter";
 
     private int epoch;
     private int counter;
@@ -26,6 +29,19 @@ public class Zxid {
         return new JsonObject()
             .put(EPOCH_KEY, epoch)
             .put(COUNTER_KEY, counter);
+    }
+
+    public boolean isLaterThan(final Zxid other) {
+        log.traceEntry(() -> other);
+        if (epoch != other.epoch) {
+            return log.traceExit(epoch > other.epoch);
+        }
+        return log.traceExit(counter > other.counter);
+    }
+
+    public static int comparator(final Zxid a, final Zxid b) {
+        log.traceEntry(() -> a, () -> b);
+        return log.traceExit(b.isLaterThan(a) ? -1 : a.equals(b) ? 0 : 1);
     }
 
     @Override

--- a/zookeeper/src/main/java/io/julian/zookeeper/synchronize/FollowerSynchronizeHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/synchronize/FollowerSynchronizeHandler.java
@@ -1,0 +1,79 @@
+package io.julian.zookeeper.synchronize;
+
+import io.julian.server.api.client.ServerClient;
+import io.julian.server.api.exceptions.NoIDException;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.control.ClientMessage;
+import io.julian.zookeeper.controller.State;
+import io.julian.zookeeper.election.CandidateInformationRegistry;
+import io.julian.zookeeper.models.Proposal;
+import io.julian.zookeeper.models.Zxid;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FollowerSynchronizeHandler {
+    private static final Logger log = LogManager.getLogger(FollowerSynchronizeHandler.class);
+    private final Vertx vertx;
+    private final State state;
+    private final CandidateInformationRegistry registry;
+    private final ServerClient client;
+
+    public FollowerSynchronizeHandler(final Vertx vertx, final State state, final CandidateInformationRegistry registry, final ServerClient client) {
+        this.vertx = vertx;
+        this.state = state;
+        this.registry = registry;
+        this.client = client;
+    }
+
+    public Future<Void> synchronizeWithLeaderState(final State leader) {
+        log.traceEntry(() -> leader);
+        Promise<Void> synchronize = Promise.promise();
+        log.info("Synchronizing with leader state");
+        vertx.executeBlocking(future -> {
+            List<Proposal> missingProposals = findMissingProposals(leader);
+            for (Proposal proposal : missingProposals) {
+                ClientMessage message = proposal.getNewState();
+                if (message.getRequest().equals(HTTPRequest.POST)) {
+                    state.getMessageStore().putMessage(message.getMessageId(), message.getMessage());
+                } else {
+                    try {
+                        state.getMessageStore().deleteMessageFromServer(message.getMessageId());
+                    } catch (NoIDException e) {
+                        log.info("Tried to delete message not in server, but ignoring");
+                    }
+                }
+            }
+            state.setState(leader);
+            log.info("Finished synchronizing with leader state");
+            future.complete();
+        },
+            res -> synchronize.complete());
+        return log.traceExit(synchronize.future());
+    }
+
+    public List<Proposal> findMissingProposals(final State leader) {
+        log.traceEntry(() -> leader);
+        List<Proposal> proposals = new ArrayList<>();
+        final Zxid currentId = new Zxid(state.getLeaderEpoch(), state.getCounter());
+        log.info(String.format("Finding missing proposals later than %s from leader state", currentId));
+        for (int i = 0; i < leader.getLastAcceptedIndex(); i++) {
+            Proposal proposal = leader.getHistory().get(i);
+            if (proposal.getTransactionId().isLaterThan(currentId)) {
+                proposals.add(proposal);
+            }
+        }
+        proposals.sort((a, b) -> Zxid.comparator(a.getTransactionId(), b.getTransactionId()));
+        return log.traceExit(proposals);
+    }
+
+    public State getState() {
+        log.traceEntry();
+        return log.traceExit(state);
+    }
+}

--- a/zookeeper/src/main/java/io/julian/zookeeper/synchronize/LeaderSynchronizeHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/synchronize/LeaderSynchronizeHandler.java
@@ -1,0 +1,88 @@
+package io.julian.zookeeper.synchronize;
+
+import io.julian.server.api.client.RegistryManager;
+import io.julian.server.api.client.ServerClient;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.coordination.CoordinationMessage;
+import io.julian.server.models.coordination.CoordinationMetadata;
+import io.julian.zookeeper.controller.State;
+import io.julian.zookeeper.discovery.LeaderDiscoveryHandler;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class LeaderSynchronizeHandler {
+    private static final Logger log = LogManager.getLogger(LeaderDiscoveryHandler.class);
+
+    private final State state;
+    private final RegistryManager manager;
+    private final ServerClient client;
+    private final AtomicInteger acknowledgements = new AtomicInteger();
+
+    public LeaderSynchronizeHandler(final State state, final RegistryManager manager, final ServerClient client) {
+        this.state = state;
+        this.manager = manager;
+        this.client = client;
+    }
+
+    public Future<Void> broadcastState() {
+        log.traceEntry();
+        log.info("Leader broadcasting state to followers");
+        Promise<Void> res = Promise.promise();
+        List<Future> broadcast = manager
+            .getOtherServers()
+            .stream()
+            .map(server -> client.sendCoordinateMessageToServer(server, getCoordinationMessage()))
+            .collect(Collectors.toList());
+
+        CompositeFuture all = CompositeFuture.all(broadcast)
+            .onSuccess(v -> {
+                log.info("Leader successfully broadcast state to followers");
+                acknowledgements.set(0);
+                res.complete();
+            })
+            .onFailure(cause -> {
+                log.info("Leader unsuccessfully broadcast state to followers");
+                log.error(cause);
+                res.fail(cause);
+            });
+
+        return log.traceExit(res.future());
+    }
+
+    public void incrementAcknowledgement() {
+        log.traceEntry();
+        log.info("Leader has received synchronize acknowledgement from follower");
+        acknowledgements.getAndIncrement();
+        log.traceExit();
+    }
+
+    public boolean hasReceivedAcknowledgementsFromFollowers() {
+        log.traceEntry();
+        return log.traceExit(acknowledgements.get() == manager.getOtherServers().size());
+    }
+
+    public CoordinationMessage getCoordinationMessage() {
+        log.traceEntry();
+        return log.traceExit(new CoordinationMessage(
+            new CoordinationMetadata(HTTPRequest.UNKNOWN, null, SynchronizeHandler.SYNCHRONIZE_TYPE),
+            null,
+            state.toJson()));
+    }
+
+    public State getState() {
+        log.traceEntry();
+        return log.traceExit(state);
+    }
+
+    public int getAcknowledgements() {
+        log.traceEntry();
+        return log.traceExit(acknowledgements.get());
+    }
+}

--- a/zookeeper/src/main/java/io/julian/zookeeper/synchronize/SynchronizeHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/synchronize/SynchronizeHandler.java
@@ -1,5 +1,57 @@
 package io.julian.zookeeper.synchronize;
 
+import io.julian.server.api.client.RegistryManager;
+import io.julian.server.api.client.ServerClient;
+import io.julian.server.components.Controller;
+import io.julian.server.models.coordination.CoordinationMessage;
+import io.julian.zookeeper.controller.State;
+import io.julian.zookeeper.election.CandidateInformationRegistry;
+import io.julian.zookeeper.election.LeadershipElectionHandler;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class SynchronizeHandler {
+    private static final Logger log = LogManager.getLogger(SynchronizeHandler.class);
     public static final String SYNCHRONIZE_TYPE = "synchronize";
+
+    private final LeaderSynchronizeHandler leader;
+    private final FollowerSynchronizeHandler follower;
+    private final Controller controller;
+
+    public SynchronizeHandler(final Vertx vertx, final State state, final RegistryManager registryManager, final ServerClient client,
+                              final CandidateInformationRegistry candidateInformationRegistry, final Controller controller) {
+        this.leader = new LeaderSynchronizeHandler(state, registryManager, client);
+        this.follower = new FollowerSynchronizeHandler(vertx, state, candidateInformationRegistry, client);
+        this.controller = controller;
+    }
+
+    public Future<Void> broadcastState() {
+        log.traceEntry();
+        log.info("Leader broadcasting state to followers to synchronize");
+        return log.traceExit(leader.broadcastState());
+    }
+
+    public Future<Void> handleCoordinationMessage(final CoordinationMessage message) {
+        log.traceEntry(() -> message);
+        if (controller.getLabel().equals(LeadershipElectionHandler.LEADER_LABEL)) {
+            log.info("Leader has received acknowledgement from the messages");
+            leader.incrementAcknowledgement();
+            return log.traceExit(Future.succeededFuture());
+        }
+        log.info("Follower has received synchronize state update from leader");
+        State state = State.fromJson(message.getDefinition());
+        return log.traceExit(this.follower.replyToLeader(state));
+    }
+
+    public boolean hasReceivedEnoughAcknowledgements() {
+        log.traceEntry();
+        return log.traceExit(leader.hasReceivedAcknowledgementsFromFollowers());
+    }
+
+    public LeaderSynchronizeHandler getLeaderSynchronizeHandler() {
+        log.traceEntry();
+        return log.traceExit(leader);
+    }
 }

--- a/zookeeper/src/main/java/io/julian/zookeeper/synchronize/SynchronizeHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/synchronize/SynchronizeHandler.java
@@ -1,0 +1,5 @@
+package io.julian.zookeeper.synchronize;
+
+public class SynchronizeHandler {
+    public static final String SYNCHRONIZE_TYPE = "synchronize";
+}

--- a/zookeeper/src/main/java/io/julian/zookeeper/write/WriteHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/write/WriteHandler.java
@@ -84,7 +84,7 @@ public class WriteHandler {
      */
     public Future<Void> initialProposalUpdate(final ClientMessage message) {
         log.traceEntry(() -> message);
-        final Zxid id = new Zxid(state.getLeaderEpoch(), state.getAndIncrementCounter());
+        final Zxid id = new Zxid(state.getLeaderEpoch(), state.incrementAndGetCounter());
         log.info(String.format("Adding proposal %s to history and broadcasting proposal", id));
         return log.traceExit(state.addProposal(new Proposal(message, id))
             .compose(v -> state.processStateUpdate(id))
@@ -105,7 +105,6 @@ public class WriteHandler {
     /*
      * Getters and Setters
      */
-
     public boolean isLeader() {
         log.traceEntry();
         return log.traceExit(controller.getLabel().equals(LeadershipElectionHandler.LEADER_LABEL));

--- a/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
@@ -100,7 +100,7 @@ public class IntegrationTest extends AbstractServerBase {
         client.sendCoordinateMessageToServer(AbstractServerBase.DEFAULT_SEVER_CONFIG, new CoordinationMessage(HTTPRequest.POST, new JsonObject()))
             .onComplete(context.asyncAssertSuccess(res ->
                 // Wait 2 seconds to let servers stabilize
-                vertx.setTimer(1000, complete -> async.complete())));
+                vertx.setTimer(2000, complete -> async.complete())));
         async.awaitSuccess();
     }
 

--- a/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
@@ -71,7 +71,7 @@ public class IntegrationTest extends AbstractServerBase {
         tearDownServer(context, server2);
     }
 
-    @Test
+    @Test(timeout = 300000)
     public void TestFollowerWriteRequestForwardsToLeader(final TestContext context) {
         TestServerComponents server1 = setUpZookeeperApiServer(context, DEFAULT_SEVER_CONFIG);
         TestServerComponents server2 = setUpZookeeperApiServer(context, SECOND_SERVER_CONFIG);

--- a/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
@@ -84,7 +84,7 @@ public class IntegrationTest extends AbstractServerBase {
         TestClient client = createTestClient();
         Async async = context.async();
         client.POST_MESSAGE(follower.configuration.getHost(), follower.configuration.getPort(), MESSAGE)
-            .onComplete(v -> vertx.setTimer(1500, v2 -> {
+            .onComplete(v -> vertx.setTimer(2500, v2 -> {
                 Assert.assertEquals(1, server1.server.getMessages().getNumberOfMessages());
                 Assert.assertEquals(1, server2.server.getMessages().getNumberOfMessages());
                 async.complete();

--- a/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/IntegrationTest.java
@@ -41,7 +41,7 @@ public class IntegrationTest extends AbstractServerBase {
             .forEach(server -> {
                 ZookeeperAlgorithm algorithm = (ZookeeperAlgorithm) server.server.getVerticle().getAlgorithm();
                 Assert.assertEquals(epoch, algorithm.getState().getLeaderEpoch());
-                Assert.assertEquals(epoch, algorithm.getState().getLeaderEpoch());
+                Assert.assertEquals(counter, algorithm.getState().getCounter());
             });
 
         tearDownServer(context, server1);

--- a/zookeeper/src/test/java/io/julian/zookeeper/TestServerComponents.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/TestServerComponents.java
@@ -64,7 +64,7 @@ public class TestServerComponents {
         server = null;
         api = null;
         Async async = context.async();
-        vertx.undeploy(deploymentID.get(), context.asyncAssertSuccess(v -> vertx.setTimer(500, v1 -> async.complete())));
+        vertx.undeploy(deploymentID.get(), context.asyncAssertSuccess(v -> async.complete()));
         async.awaitSuccess();
     }
 }

--- a/zookeeper/src/test/java/io/julian/zookeeper/TestServerComponents.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/TestServerComponents.java
@@ -64,7 +64,7 @@ public class TestServerComponents {
         server = null;
         api = null;
         Async async = context.async();
-        vertx.undeploy(deploymentID.get(), context.asyncAssertSuccess(v -> async.complete()));
+        vertx.undeploy(deploymentID.get(), context.asyncAssertSuccess(v -> vertx.setTimer(500, v1 -> async.complete())));
         async.awaitSuccess();
     }
 }

--- a/zookeeper/src/test/java/io/julian/zookeeper/controller/StateTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/controller/StateTest.java
@@ -232,10 +232,10 @@ public class StateTest {
     }
 
     @Test
-    public void TestToJson() {
+    public void TestToJson(final TestContext context) {
         MessageStore messageStore = new MessageStore();
         State state = new State(vertx, messageStore);
-        state.addProposal(new Proposal(POST_MESSAGE, ID));
+        addProposal(context, state, new Proposal(POST_MESSAGE, ID));
         JsonArray expectedArray = new JsonArray();
         expectedArray.add(new Proposal(POST_MESSAGE, ID).toJson());
         JsonObject json = state.toJson();

--- a/zookeeper/src/test/java/io/julian/zookeeper/controller/StateTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/controller/StateTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 @RunWith(VertxUnitRunner.class)
 public class StateTest {
@@ -265,6 +266,21 @@ public class StateTest {
         Assert.assertEquals(ID.toJson().encodePrettily(), state.getHistory().get(0).getTransactionId().toJson().encodePrettily());
         Assert.assertEquals(counter, state.getCounter());
         Assert.assertEquals(lastAcceptedIndex, state.getLastAcceptedIndex());
+    }
+
+    @Test
+    public void TestIsLaterThan() {
+        State lowest = new State(Collections.emptyList(), 0, 0, 0);
+        State middle = new State(Collections.emptyList(), 0, 1, 10);
+        State highest = new State(Collections.emptyList(), 0, 2, 0);
+
+        Assert.assertTrue(highest.isLaterThanState(middle));
+        Assert.assertTrue(highest.isLaterThanState(lowest));
+        Assert.assertTrue(middle.isLaterThanState(lowest));
+
+        Assert.assertFalse(middle.isLaterThanState(highest));
+        Assert.assertFalse(lowest.isLaterThanState(middle));
+        Assert.assertFalse(lowest.isLaterThanState(highest));
     }
 
     @After

--- a/zookeeper/src/test/java/io/julian/zookeeper/controller/StateTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/controller/StateTest.java
@@ -173,7 +173,7 @@ public class StateTest {
     public void processStateUpdateProcessesPOSTUpdate(final TestContext context) {
         MessageStore messageStore = new MessageStore();
         State state = new State(vertx, messageStore);
-        state.addProposal(new Proposal(POST_MESSAGE, ID));
+        addProposal(context, state, new Proposal(POST_MESSAGE, ID));
 
         Future<Void> update = state.processStateUpdate(ID);
         Async async = context.async();
@@ -189,7 +189,7 @@ public class StateTest {
         MessageStore messageStore = new MessageStore();
         State state = new State(vertx, messageStore);
         messageStore.putMessage(MESSAGE_ID, new JsonObject());
-        state.addProposal(new Proposal(DELETE_MESSAGE, ID));
+        addProposal(context, state, new Proposal(DELETE_MESSAGE, ID));
 
         Future<Void> update = state.processStateUpdate(ID);
         Async async = context.async();
@@ -204,7 +204,8 @@ public class StateTest {
     public void processStateUpdateFailsDELETEUpdate(final TestContext context) {
         MessageStore messageStore = new MessageStore();
         State state = new State(vertx, messageStore);
-        state.addProposal(new Proposal(DELETE_MESSAGE, ID));
+        addProposal(context, state, new Proposal(DELETE_MESSAGE, ID));
+
 
         Future<Void> update = state.processStateUpdate(ID);
         Async async = context.async();
@@ -219,7 +220,8 @@ public class StateTest {
     public void processStateUpdateFailsPOSTUpdate(final TestContext context) {
         MessageStore messageStore = new MessageStore();
         State state = new State(vertx, messageStore);
-        state.addProposal(new Proposal(POST_MESSAGE, ID));
+        addProposal(context, state, new Proposal(POST_MESSAGE, ID));
+
         messageStore.putMessage(MESSAGE_ID, new JsonObject());
 
         Future<Void> update = state.processStateUpdate(ID);

--- a/zookeeper/src/test/java/io/julian/zookeeper/discovery/DiscoveryHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/discovery/DiscoveryHandlerTest.java
@@ -5,6 +5,7 @@ import io.julian.server.components.Configuration;
 import io.julian.server.components.Controller;
 import io.julian.server.components.MessageStore;
 import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.control.ClientMessage;
 import io.julian.server.models.control.ServerConfiguration;
 import io.julian.server.models.coordination.CoordinationMessage;
 import io.julian.server.models.coordination.CoordinationMetadata;
@@ -13,32 +14,37 @@ import io.julian.zookeeper.TestServerComponents;
 import io.julian.zookeeper.controller.State;
 import io.julian.zookeeper.election.CandidateInformationRegistry;
 import io.julian.zookeeper.election.LeadershipElectionHandler;
+import io.julian.zookeeper.models.Proposal;
 import io.julian.zookeeper.models.Zxid;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
+
 public class DiscoveryHandlerTest extends AbstractServerBase {
     private final static int EPOCH = 12;
     private final static int COUNTER = 2512;
-    private final static Zxid ID = new Zxid(EPOCH, COUNTER);
+    private final static Proposal PROPOSAL = new Proposal(new ClientMessage(HTTPRequest.POST, new JsonObject(), null), new Zxid(0, 0));
+    private final static State STATE = new State(Collections.singletonList(PROPOSAL), 0, EPOCH, COUNTER);
 
     @Test
-    public void TestResetAsFollower() {
-        DiscoveryHandler handler = createDiscoveryHandler(true);
-        handler.getState().setCounter(1);
-        handler.getState().setLeaderEpoch(2);
+    public void TestReset() {
+        DiscoveryHandler handler = createDiscoveryHandler(false);
+        handler.getLeaderHandler().setLatestState(new State(vertx, new MessageStore()));
+        handler.getLeaderHandler().getLatestState().setLeaderEpoch(2);
+        handler.getLeaderHandler().getLatestState().setCounter(1);
         Assert.assertFalse(handler.hasBroadcastFollowerZXID());
-        Assert.assertEquals(0, handler.getLeaderHandler().getCounter());
-        Assert.assertEquals(0, handler.getLeaderHandler().getEpoch());
+        Assert.assertEquals(0, handler.getState().getCounter());
+        Assert.assertEquals(0, handler.getState().getLeaderEpoch());
 
         handler.reset();
-        Assert.assertTrue(handler.hasBroadcastFollowerZXID());
-        Assert.assertEquals(1, handler.getLeaderHandler().getCounter());
-        Assert.assertEquals(2, handler.getLeaderHandler().getEpoch());
+        Assert.assertFalse(handler.hasBroadcastFollowerZXID());
+        Assert.assertEquals(1, handler.getState().getCounter());
+        Assert.assertEquals(2, handler.getState().getLeaderEpoch());
     }
-
     @Test
     public void TestBroadcastToFollowersSucceeds(final TestContext context) {
         TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
@@ -89,7 +95,7 @@ public class DiscoveryHandlerTest extends AbstractServerBase {
         DiscoveryHandler handler = createDiscoveryHandler(false, SECOND_SERVER_CONFIG);
 
         Async async = context.async();
-        handler.handleCoordinationMessage(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN), null, ID.toJson()))
+        handler.handleCoordinationMessage(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN), null, STATE.toJson()))
             .onComplete(context.asyncAssertFailure(cause -> {
                 Assert.assertEquals(DiscoveryHandler.NOT_ENOUGH_RESPONSES_ERROR, cause.getMessage());
                 async.complete();
@@ -104,7 +110,7 @@ public class DiscoveryHandlerTest extends AbstractServerBase {
         DiscoveryHandler handler = createDiscoveryHandler(false);
 
         Async async = context.async();
-        handler.handleCoordinationMessage(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN), null, ID.toJson()))
+        handler.handleCoordinationMessage(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN), null, STATE.toJson()))
             .onComplete(context.asyncAssertSuccess(v -> async.complete()));
         async.awaitSuccess();
         tearDownServer(context, server);
@@ -115,27 +121,12 @@ public class DiscoveryHandlerTest extends AbstractServerBase {
         DiscoveryHandler handler = createDiscoveryHandler(false);
 
         Async async = context.async();
-        handler.handleCoordinationMessage(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN), null, ID.toJson()))
+        handler.handleCoordinationMessage(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN), null, STATE.toJson()))
             .onComplete(context.asyncAssertFailure(cause -> {
                 Assert.assertEquals(CONNECTION_REFUSED_EXCEPTION, cause.getMessage());
                 async.complete();
             }));
         async.awaitSuccess();
-    }
-
-    @Test
-    public void TestResetAsLeader() {
-        DiscoveryHandler handler = createDiscoveryHandler(false);
-        handler.getState().setCounter(1);
-        handler.getState().setLeaderEpoch(2);
-        Assert.assertFalse(handler.hasBroadcastFollowerZXID());
-        Assert.assertEquals(0, handler.getLeaderHandler().getCounter());
-        Assert.assertEquals(0, handler.getLeaderHandler().getEpoch());
-
-        handler.reset();
-        Assert.assertFalse(handler.hasBroadcastFollowerZXID());
-        Assert.assertEquals(1, handler.getLeaderHandler().getCounter());
-        Assert.assertEquals(2, handler.getLeaderHandler().getEpoch());
     }
 
     private DiscoveryHandler createDiscoveryHandler(final boolean isFollower, final ServerConfiguration... configurations) {

--- a/zookeeper/src/test/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandlerTest.java
@@ -14,19 +14,15 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class FollowerDiscoveryHandlerTest extends AbstractServerBase {
-    private final static int EPOCH = 12;
-    private final static int COUNTER = 4321;
-    private final static Zxid ID = new Zxid(EPOCH, COUNTER);
-
     @Test
     public void TestCreateCoordinationMessage() {
         CandidateInformationRegistry registry = createTestCandidateInformationRegistry(false);
         FollowerDiscoveryHandler handler = getTestHandler(registry);
-        CoordinationMessage message = handler.createCoordinationMessage(ID);
+        CoordinationMessage message = handler.createCoordinationMessage();
         Assert.assertEquals(HTTPRequest.UNKNOWN, message.getMetadata().getRequest());
         Assert.assertEquals(DiscoveryHandler.DISCOVERY_TYPE, message.getMetadata().getType());
         Assert.assertNull(message.getMessage());
-        Assert.assertEquals(ID.toJson().encodePrettily(), message.getDefinition().encodePrettily());
+        Assert.assertEquals(new State(vertx, new MessageStore()).toJson().encodePrettily(), message.getDefinition().encodePrettily());
     }
 
     @Test

--- a/zookeeper/src/test/java/io/julian/zookeeper/models/ZxidTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/models/ZxidTest.java
@@ -4,7 +4,9 @@ import io.vertx.core.json.JsonObject;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 public class ZxidTest {
     public static final int EPOCH = 32;
@@ -57,6 +59,39 @@ public class ZxidTest {
         set.add(first);
         Assert.assertTrue(set.contains(first));
         Assert.assertTrue(set.contains(second));
+    }
+
+    @Test
+    public void TestIsLaterThan() {
+        Zxid highest = JSON.mapTo(Zxid.class);
+        Zxid lowest = new Zxid(0, 0);
+        Zxid middle = new Zxid(EPOCH - 1, COUNTER + 10);
+
+        Assert.assertTrue(highest.isLaterThan(lowest));
+        Assert.assertTrue(highest.isLaterThan(middle));
+        Assert.assertTrue(middle.isLaterThan(lowest));
+
+        Assert.assertFalse(middle.isLaterThan(highest));
+        Assert.assertFalse(lowest.isLaterThan(middle));
+        Assert.assertFalse(lowest.isLaterThan(highest));
+    }
+
+    @Test
+    public void TestComparatorCanSort() {
+        Zxid highest = JSON.mapTo(Zxid.class);
+        Zxid lowest = new Zxid(0, 0);
+        Zxid middle = new Zxid(EPOCH - 1, COUNTER + 10);
+
+        List<Zxid> list = Arrays.asList(highest, lowest, middle);
+        list.sort(Zxid::comparator);
+
+        boolean isSorted = true;
+        for (int i = 1; i < list.size(); i++) {
+            if (!list.get(i).isLaterThan(list.get(i - 1))) {
+                isSorted = false;
+            }
+        }
+        Assert.assertTrue(isSorted);
     }
 
     @Test

--- a/zookeeper/src/test/java/io/julian/zookeeper/synchronize/FollowerSynchronizeHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/synchronize/FollowerSynchronizeHandlerTest.java
@@ -1,0 +1,108 @@
+package io.julian.zookeeper.synchronize;
+
+import io.julian.server.components.MessageStore;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.control.ClientMessage;
+import io.julian.zookeeper.AbstractServerBase;
+import io.julian.zookeeper.controller.State;
+import io.julian.zookeeper.models.Proposal;
+import io.julian.zookeeper.models.Zxid;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FollowerSynchronizeHandlerTest extends AbstractServerBase {
+    private static final int INITIALIZED_MESSAGES = 5;
+    private static final Zxid EARLIEST_ID = new Zxid(0, 1);
+    private static final Zxid LATEST_ID = new Zxid(12, 1);
+
+    private static final JsonObject POST = new JsonObject().put("random", "key");
+
+    @Test
+    public void TestSynchronizeWithLeaderState(final TestContext context) {
+        FollowerSynchronizeHandler handler = createTestHandler();
+        State leader = createInitializedState(context);
+
+        Async async = context.async();
+        handler.synchronizeWithLeaderState(leader)
+            .onComplete(context.asyncAssertSuccess(v -> {
+                context.assertEquals(INITIALIZED_MESSAGES, handler.getState().getHistory().size());
+                boolean isSorted = true;
+                for (int i = 0; i < INITIALIZED_MESSAGES; i++) {
+                    if (i > 0 && !handler.getState().getHistory().get(i).getTransactionId().isLaterThan(handler.getState().getHistory().get(i - 1).getTransactionId())) {
+                        isSorted = false;
+                    }
+                    Assert.assertEquals(leader.getHistory().get(i).getTransactionId(), handler.getState().getHistory().get(i).getTransactionId());
+                }
+                Assert.assertEquals(leader.getLeaderEpoch(), handler.getState().getLeaderEpoch());
+                Assert.assertEquals(leader.getCounter(), handler.getState().getCounter());
+                Assert.assertEquals(leader.getLastAcceptedIndex(), handler.getState().getLastAcceptedIndex());
+                Assert.assertTrue(isSorted);
+                async.complete();
+            }));
+        async.awaitSuccess();
+        Assert.assertEquals(leader.getMessageStore().getNumberOfMessages(), handler.getState().getMessageStore().getNumberOfMessages());
+        for (int i = 0; i < INITIALIZED_MESSAGES; i++) {
+            Assert.assertEquals(
+                leader.getMessageStore().getMessage(Integer.toString(i)).encodePrettily(),
+                handler.getState().getMessageStore().getMessage(Integer.toString(i)).encodePrettily());
+        }
+    }
+
+    @Test
+    public void TestFindMissingProposalsWhenEmptyState(final TestContext context) {
+        FollowerSynchronizeHandler handler = createTestHandler();
+        List<Proposal> proposals = handler.findMissingProposals(createInitializedState(context));
+
+        int expectedMessages = INITIALIZED_MESSAGES;
+        Assert.assertEquals(expectedMessages, proposals.size());
+        for (int i = 0; i < expectedMessages; i++) {
+            Assert.assertEquals(Integer.toString(i), proposals.get(i).getNewState().getMessageId());
+            Assert.assertEquals(POST.encodePrettily(), proposals.get(i).getNewState().getMessage().encodePrettily());
+        }
+    }
+
+    @Test
+    public void TestFindMissingProposalsWhenLastAcceptedLessThanTotalList(final TestContext context) {
+        int expectedMessages = INITIALIZED_MESSAGES - 2;
+        FollowerSynchronizeHandler handler = createTestHandler();
+        State leader = createInitializedState(context);
+        leader.setLastAcceptedIndex(expectedMessages);
+        List<Proposal> proposals = handler.findMissingProposals(leader);
+
+        Assert.assertEquals(expectedMessages, proposals.size());
+        for (int i = 0; i < expectedMessages; i++) {
+            Assert.assertEquals(Integer.toString(i), proposals.get(i).getNewState().getMessageId());
+            Assert.assertEquals(POST.encodePrettily(), proposals.get(i).getNewState().getMessage().encodePrettily());
+        }
+    }
+
+    private FollowerSynchronizeHandler createTestHandler() {
+        return new FollowerSynchronizeHandler(vertx, new State(vertx, new MessageStore()), createTestCandidateInformationRegistry(true), createServerClient());
+    }
+
+    private State createInitializedState(final TestContext context) {
+        State state = new State(vertx, new MessageStore());
+        List<Future> stateUpdate = new ArrayList<>();
+        for (int i = 0; i < INITIALIZED_MESSAGES; i++) {
+            ClientMessage message = new ClientMessage(HTTPRequest.POST, POST, Integer.toString(i));
+            stateUpdate.add(state.addProposal(new Proposal(message, new Zxid(EARLIEST_ID.getEpoch(), i + 1))));
+            state.getMessageStore().putMessage(message.getMessageId(), message.getMessage());
+        }
+        Async async = context.async();
+        CompositeFuture.all(stateUpdate)
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+        async.awaitSuccess();
+        state.setCounter(INITIALIZED_MESSAGES - 1);
+        state.setLeaderEpoch(1);
+        state.setLastAcceptedIndexIfGreater(INITIALIZED_MESSAGES - 1);
+        return state;
+    }
+}

--- a/zookeeper/src/test/java/io/julian/zookeeper/synchronize/FollowerSynchronizeHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/synchronize/FollowerSynchronizeHandlerTest.java
@@ -114,7 +114,7 @@ public class FollowerSynchronizeHandlerTest extends AbstractServerBase {
         Assert.assertEquals(leader.getLeaderEpoch(), handler.getLeaderEpoch());
         Assert.assertEquals(leader.getCounter(), handler.getCounter());
         Assert.assertEquals(leader.getLastAcceptedIndex(), handler.getLastAcceptedIndex());
-        Assert.assertTrue(isSorted);
+        Assert.assertTrue("handler history is not in sorted order", isSorted);
     }
 
     private void checkMessageStoreIsTheSame(final MessageStore leader, final MessageStore handler) {
@@ -140,7 +140,7 @@ public class FollowerSynchronizeHandlerTest extends AbstractServerBase {
         async.awaitSuccess();
         state.setCounter(INITIALIZED_MESSAGES - 1);
         state.setLeaderEpoch(1);
-        state.setLastAcceptedIndexIfGreater(INITIALIZED_MESSAGES - 1);
+        state.setLastAcceptedIndex(INITIALIZED_MESSAGES - 1);
         return state;
     }
 }

--- a/zookeeper/src/test/java/io/julian/zookeeper/synchronize/LeaderSynchronizeHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/synchronize/LeaderSynchronizeHandlerTest.java
@@ -1,0 +1,77 @@
+package io.julian.zookeeper.synchronize;
+
+import io.julian.server.api.client.RegistryManager;
+import io.julian.server.components.MessageStore;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.coordination.CoordinationMessage;
+import io.julian.zookeeper.AbstractServerBase;
+import io.julian.zookeeper.TestServerComponents;
+import io.julian.zookeeper.controller.State;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LeaderSynchronizeHandlerTest extends AbstractServerBase {
+    @Test
+    public void TestCoordinationMessage() {
+        LeaderSynchronizeHandler handler = createTestHandler();
+        CoordinationMessage message = handler.getCoordinationMessage();
+        Assert.assertEquals(HTTPRequest.UNKNOWN, message.getMetadata().getRequest());
+        Assert.assertEquals(SynchronizeHandler.SYNCHRONIZE_TYPE, message.getMetadata().getType());
+
+        Assert.assertEquals(SynchronizeHandler.SYNCHRONIZE_TYPE, message.getMetadata().getType());
+        Assert.assertEquals(handler.getState().toJson().encodePrettily(), message.getDefinition().encodePrettily());
+        Assert.assertNull(message.getMessage());
+    }
+
+    @Test
+    public void TestBroadcastStateIsSuccessful(final TestContext context) {
+        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        LeaderSynchronizeHandler handler = createTestHandler();
+        Async async = context.async();
+        handler.broadcastState()
+            .onComplete(context.asyncAssertSuccess(v -> {
+                Assert.assertEquals(0, handler.getAcknowledgements());
+                async.complete();
+            }));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+    }
+
+    @Test
+    public void TestBroadcastStateFails(final TestContext context) {
+        LeaderSynchronizeHandler handler = createTestHandler();
+        Async async = context.async();
+        handler.broadcastState()
+            .onComplete(context.asyncAssertFailure(cause -> {
+                Assert.assertEquals(CONNECTION_REFUSED_EXCEPTION, cause.getMessage());
+                Assert.assertEquals(0, handler.getAcknowledgements());
+                async.complete();
+            }));
+        async.awaitSuccess();
+    }
+
+    @Test
+    public void TestIncrementAcknowledgement() {
+        LeaderSynchronizeHandler handler = createTestHandler();
+        Assert.assertEquals(0, handler.getAcknowledgements());
+        handler.incrementAcknowledgement();
+        Assert.assertEquals(1, handler.getAcknowledgements());
+    }
+
+    @Test
+    public void TestHasEnoughAcknowledgements() {
+        LeaderSynchronizeHandler handler = createTestHandler();
+        RegistryManager manager = createTestRegistryManager();
+        while (handler.getAcknowledgements() < manager.getOtherServers().size()) {
+            Assert.assertFalse(handler.hasReceivedAcknowledgementsFromFollowers());
+            handler.incrementAcknowledgement();
+        }
+        Assert.assertTrue(handler.hasReceivedAcknowledgementsFromFollowers());
+    }
+
+    private LeaderSynchronizeHandler createTestHandler() {
+        return new LeaderSynchronizeHandler(new State(vertx, new MessageStore()), createTestRegistryManager(), createServerClient());
+    }
+}

--- a/zookeeper/src/test/java/io/julian/zookeeper/synchronize/SynchronizeHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/synchronize/SynchronizeHandlerTest.java
@@ -1,0 +1,88 @@
+package io.julian.zookeeper.synchronize;
+
+import io.julian.server.components.Configuration;
+import io.julian.server.components.Controller;
+import io.julian.server.components.MessageStore;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.control.ClientMessage;
+import io.julian.server.models.coordination.CoordinationMessage;
+import io.julian.zookeeper.AbstractServerBase;
+import io.julian.zookeeper.TestServerComponents;
+import io.julian.zookeeper.controller.State;
+import io.julian.zookeeper.election.LeadershipElectionHandler;
+import io.julian.zookeeper.models.Proposal;
+import io.julian.zookeeper.models.Zxid;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SynchronizeHandlerTest extends AbstractServerBase {
+    @Test
+    public void TestHasReceivedEnoughAcknowledgements() {
+        SynchronizeHandler handler = createTestHandler(true);
+        Assert.assertFalse(handler.hasReceivedEnoughAcknowledgements());
+        handler.handleCoordinationMessage(new CoordinationMessage(HTTPRequest.POST, new JsonObject()));
+        Assert.assertTrue(handler.hasReceivedEnoughAcknowledgements());
+    }
+
+    @Test
+    public void TestHandleCoordinationMessageAsLeader(final TestContext context) {
+        SynchronizeHandler handler = createTestHandler(true);
+        Assert.assertFalse(handler.hasReceivedEnoughAcknowledgements());
+        Async async = context.async();
+        handler.handleCoordinationMessage(new CoordinationMessage(HTTPRequest.POST, new JsonObject()))
+            .onComplete(context.asyncAssertSuccess(v -> {
+                Assert.assertTrue(handler.hasReceivedEnoughAcknowledgements());
+                async.complete();
+            }));
+        async.awaitSuccess();
+    }
+
+    @Test
+    public void TestHandleCoordinationMessageAsFollowerSucceeds(final TestContext context) {
+        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        SynchronizeHandler handler = createTestHandler(false);
+        State state = createInitializedState(context);
+        Async async = context.async();
+        handler.handleCoordinationMessage(new CoordinationMessage(HTTPRequest.POST, state.toJson()))
+            .onComplete(context.asyncAssertSuccess(v -> {
+                Assert.assertEquals(1, handler.getLeaderSynchronizeHandler().getState().getHistory().size());
+                async.complete();
+            }));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+    }
+
+    @Test
+    public void TestHandleCoordinationMessageAsFollowerFails(final TestContext context) {
+        SynchronizeHandler handler = createTestHandler(false);
+        State state = createInitializedState(context);
+        Async async = context.async();
+        handler.handleCoordinationMessage(new CoordinationMessage(HTTPRequest.POST, state.toJson()))
+            .onComplete(context.asyncAssertFailure(cause -> {
+                Assert.assertEquals(1, handler.getLeaderSynchronizeHandler().getState().getHistory().size());
+                Assert.assertEquals(CONNECTION_REFUSED_EXCEPTION, cause.getMessage());
+                async.complete();
+            }));
+        async.awaitSuccess();
+    }
+
+    private SynchronizeHandler createTestHandler(final boolean isLeader) {
+        Controller controller = new Controller(new Configuration());
+        controller.setLabel(isLeader ? LeadershipElectionHandler.LEADER_LABEL : LeadershipElectionHandler.FOLLOWER_LABEL);
+        return new SynchronizeHandler(vertx, new State(vertx, new MessageStore()), createTestRegistryManager(),
+            createServerClient(), createTestCandidateInformationRegistry(!isLeader), controller);
+    }
+
+    private State createInitializedState(final TestContext context) {
+        State state = new State(vertx, new MessageStore());
+        Async async = context.async();
+        state.addProposal(new Proposal(new ClientMessage(HTTPRequest.POST, new JsonObject(), "0"), new Zxid(0, 1)))
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+
+        async.awaitSuccess();
+        return state;
+    }
+}

--- a/zookeeper/src/test/java/io/julian/zookeeper/write/LeaderWriteHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/write/LeaderWriteHandlerTest.java
@@ -35,7 +35,6 @@ public class LeaderWriteHandlerTest extends AbstractServerBase {
             .onComplete(context.asyncAssertSuccess(res -> async.complete()));
 
         async.awaitSuccess();
-
         tearDownServer(context, server);
     }
 
@@ -49,7 +48,6 @@ public class LeaderWriteHandlerTest extends AbstractServerBase {
                 context.assertEquals(CONNECTION_REFUSED_EXCEPTION, cause.getMessage());
                 async.complete();
             }));
-
         async.awaitSuccess();
     }
 


### PR DESCRIPTION
Zookeeper will now synchronize between the follower and the leader when needed. This is done when starting up and to ensure that all servers start at the same state.

Closes: #39 

Signed-off-by: Julian Goh <juliangohsl@gmail.com>
