### PR TITLE
Feat: Server Configuration loading

### DIFF
--- a/server/src/main/java/io/julian/server/api/DistributedAlgorithm.java
+++ b/server/src/main/java/io/julian/server/api/DistributedAlgorithm.java
@@ -24,7 +24,7 @@ public abstract class DistributedAlgorithm {
         this.controller = controller;
         this.messageStore = messageStore;
         this.client = new ServerClient(vertx);
-        this.registryManager = new RegistryManager();
+        this.registryManager = new RegistryManager(controller.getConfiguration());
         this.vertx = vertx;
     }
 

--- a/server/src/main/java/io/julian/server/api/client/RegistryManager.java
+++ b/server/src/main/java/io/julian/server/api/client/RegistryManager.java
@@ -1,9 +1,13 @@
 package io.julian.server.api.client;
 
+import io.julian.server.components.Configuration;
 import io.julian.server.models.control.ServerConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,6 +15,7 @@ import java.util.stream.Collectors;
 public class RegistryManager {
     private final Logger log = LogManager.getLogger(RegistryManager.class.getName());
     private final List<ServerConfiguration> otherServers = new ArrayList<>();
+    private final Configuration configuration = new Configuration();
 
     public List<ServerConfiguration> getOtherServers() {
         log.traceEntry();
@@ -37,5 +42,25 @@ public class RegistryManager {
         log.info(String.format("Registering server '%s:%d' with label '%s'", host, port, label));
         otherServers.add(new ServerConfiguration(host, port, label));
         log.traceExit();
+    }
+
+    /**
+     * Exposed for Testing
+     */
+    public void registerServersInsideServerConfiguration() {
+        log.traceEntry();
+        if (!configuration.getOpenapiSpecLocation().equals(Configuration.DEFAULT_SERVER_CONFIGURATION_LOCATION)) {
+            log.info(String.format("Registering servers from file in path '%s'", configuration.getServerConfigurationLocation()));
+
+        } else {
+            log.info("Skipping registering servers as no file passed in");
+        }
+        log.traceExit();
+    }
+
+    private String readFile(final String filePath) throws IOException {
+        log.traceEntry(() -> filePath);
+        Path path = Path.of(filePath);
+        return log.traceExit(Files.readString(path));
     }
 }

--- a/server/src/main/java/io/julian/server/api/client/ServerConfigReader.java
+++ b/server/src/main/java/io/julian/server/api/client/ServerConfigReader.java
@@ -1,0 +1,45 @@
+package io.julian.server.api.client;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+
+public class ServerConfigReader {
+    private final static Logger log = LogManager.getLogger(ServerConfigReader.class);
+    private final static String SERVER_DELIMITER = "\n";
+    private final static String PORT_DELIMITER = ":";
+    private final static int HOST_INDEX = 0;
+    private final static int PORT_INDEX = 1;
+
+    public ArrayList<Pair<String, Integer>> getServerConfigurations(final String filePath) throws IOException, NumberFormatException {
+        log.traceEntry(() -> filePath);
+        String contents = readFile(filePath);
+        ArrayList<Pair<String, Integer>> serverConfigurations = new ArrayList<>();
+        for (String servers : contents.split(SERVER_DELIMITER)) {
+            if (servers.length() > 0) {
+                String[] components = servers.split(PORT_DELIMITER);
+                if (components.length == 2) {
+                    String host = components[HOST_INDEX];
+                    int port = Integer.parseInt(components[PORT_INDEX]);
+                    log.info(String.format("Registering server '%s:%d'", host, port));
+                    serverConfigurations.add(Pair.of(host, port));
+                }
+            }
+        }
+        return log.traceExit(serverConfigurations);
+    }
+
+    /*
+     * Exposed for Testing
+     */
+    public String readFile(final String filePath) throws IOException {
+        log.traceEntry(() -> filePath);
+        Path path = Path.of(filePath);
+        return log.traceExit(Files.readString(path));
+    }
+}

--- a/server/src/main/java/io/julian/server/components/Configuration.java
+++ b/server/src/main/java/io/julian/server/components/Configuration.java
@@ -13,6 +13,10 @@ public class Configuration {
     public static final String DEFAULT_OPENAPI_SPEC_LOCATION = "src/main/resources/ServerEndpoints.yaml";
     private String openApiSpecLocation;
 
+    public static final String SERVER_CONFIGURATION_LOCATION = "SERVER_CONFIGURATION_LOCATION";
+    public static final String DEFAULT_SERVER_CONFIGURATION_LOCATION = "";
+    private String serverConfigurationLocation;
+
     public static final String SERVER_HOST_ENV = "SERVER_HOST";
     public static final String DEFAULT_SERVER_HOST = "localhost";
     private String host;
@@ -32,6 +36,7 @@ public class Configuration {
 
     public Configuration() {
         this.openApiSpecLocation = getOrDefault(OPENAPI_SPEC_LOCATION_ENV, DEFAULT_OPENAPI_SPEC_LOCATION);
+        this.serverConfigurationLocation = getOrDefault(SERVER_CONFIGURATION_LOCATION, DEFAULT_SERVER_CONFIGURATION_LOCATION);
         this.host = getOrDefault(SERVER_HOST_ENV, DEFAULT_SERVER_HOST);
         this.port = getOrDefault(SERVER_PORT_ENV, DEFAULT_SERVER_PORT);
         this.jarFilePath = getOrDefault(JAR_FILE_PATH_ENV, "");
@@ -69,6 +74,17 @@ public class Configuration {
     public void setOpenapiSpecLocation(final String openApiSpecLocation) {
         log.traceEntry(() -> openApiSpecLocation);
         this.openApiSpecLocation = openApiSpecLocation;
+        log.traceExit();
+    }
+
+    public String getServerConfigurationLocation() {
+        log.traceEntry();
+        return log.traceExit(serverConfigurationLocation);
+    }
+
+    public void setServerConfigurationLocation(final String serverConfigurationLocation) {
+        log.traceEntry(() -> serverConfigurationLocation);
+        this.serverConfigurationLocation = serverConfigurationLocation;
         log.traceExit();
     }
 

--- a/server/src/test/java/io/julian/server/api/client/RegistryManagerTest.java
+++ b/server/src/test/java/io/julian/server/api/client/RegistryManagerTest.java
@@ -1,5 +1,6 @@
 package io.julian.server.api.client;
 
+import io.julian.server.components.Configuration;
 import io.julian.server.models.control.ServerConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -10,14 +11,33 @@ public class RegistryManagerTest {
 
     @Test
     public void TestRegistryMangerInit() {
-        RegistryManager registryManager = new RegistryManager();
+        RegistryManager registryManager = createTestRegistryManger();
         Assert.assertNotNull(registryManager.getOtherServers());
         Assert.assertEquals(0, registryManager.getOtherServers().size());
     }
 
     @Test
+    public void TestRegistryManagerWithServersLoaded() {
+        Configuration configuration = new Configuration();
+        configuration.setServerConfigurationLocation(ServerConfigReaderTest.VALID_CONFIGURATION_PATH);
+        RegistryManager registryManager = createTestRegistryManager(configuration);
+
+        Assert.assertEquals(2, registryManager.getOtherServers().size());
+    }
+
+    @Test
+    public void TestRegistryManagerDoesNotAddCurrentConfiguration() {
+        Configuration configuration = new Configuration();
+        configuration.setServerConfigurationLocation(ServerConfigReaderTest.VALID_CONFIGURATION_PATH);
+        configuration.setServerPort(9898);
+        RegistryManager registryManager = createTestRegistryManager(configuration);
+
+        Assert.assertEquals(1, registryManager.getOtherServers().size());
+    }
+
+    @Test
     public void TestRegistryMangerAdd() {
-        RegistryManager registryManager = new RegistryManager();
+        RegistryManager registryManager = createTestRegistryManger();
         Assert.assertNotNull(registryManager.getOtherServers());
         Assert.assertEquals(0, registryManager.getOtherServers().size());
 
@@ -28,7 +48,7 @@ public class RegistryManagerTest {
 
     @Test
     public void TestRegistryMangerFindServerWithLabel() {
-        RegistryManager registryManager = new RegistryManager();
+        RegistryManager registryManager = createTestRegistryManger();
         Assert.assertNotNull(registryManager.getOtherServers());
         Assert.assertEquals(0, registryManager.getOtherServers().size());
 
@@ -38,5 +58,13 @@ public class RegistryManagerTest {
         Assert.assertEquals(2, registryManager.getOtherServers().size());
         Assert.assertEquals(1, registryManager.getOtherServersWithLabel(LABEL_CONFIGURATION.getLabel()).size());
         Assert.assertEquals(LABEL_CONFIGURATION.getHost(), registryManager.getOtherServersWithLabel(LABEL_CONFIGURATION.getLabel()).get(0).getHost());
+    }
+
+    private RegistryManager createTestRegistryManger() {
+        return createTestRegistryManager(new Configuration());
+    }
+
+    private RegistryManager createTestRegistryManager(final Configuration configuration) {
+        return new RegistryManager(configuration);
     }
 }

--- a/server/src/test/java/io/julian/server/api/client/ServerConfigReaderTest.java
+++ b/server/src/test/java/io/julian/server/api/client/ServerConfigReaderTest.java
@@ -1,0 +1,63 @@
+package io.julian.server.api.client;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class ServerConfigReaderTest {
+    public final static String RESOURCES_FOLDER = String.format("%s/src/test/resources", System.getProperty("user.dir"));
+    public final static String VALID_CONFIGURATION_PATH = String.format("%s/validServerConfiguration.txt", RESOURCES_FOLDER);
+    public final static String NUMBER_FORMAT_EXCEPTION_PATH = String.format("%s/NumberFormatExceptionConfiguration.txt", RESOURCES_FOLDER);
+
+    @Test
+    public void TestReadFileThrowsException() {
+        ServerConfigReader reader = new ServerConfigReader();
+        String invalidPath = "/invalid/path";
+        try {
+            reader.readFile(invalidPath);
+            Assert.fail();
+        } catch (final IOException e) {
+            Assert.assertEquals(invalidPath, e.getMessage());
+        }
+    }
+
+    @Test
+    public void TestReadFilePasses() {
+        ServerConfigReader reader = new ServerConfigReader();
+        String expectedContents = "localhost:9898\nlocalhost:8989";
+        try {
+            String fileContents = reader.readFile(VALID_CONFIGURATION_PATH);
+            Assert.assertEquals(expectedContents, fileContents);
+        } catch (final IOException e) {
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void TestGetServerConfigurationsPasses() {
+        ServerConfigReader reader = new ServerConfigReader();
+        try {
+            ArrayList<Pair<String, Integer>> config = reader.getServerConfigurations(VALID_CONFIGURATION_PATH);
+            Assert.assertEquals(9898, config.get(0).getRight().intValue());
+            Assert.assertEquals("localhost", config.get(0).getLeft());
+            Assert.assertEquals(8989, config.get(1).getRight().intValue());
+            Assert.assertEquals("localhost", config.get(1).getLeft());
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void TestGetServerConfigurationsThrowsNumberFormatException() {
+        ServerConfigReader reader = new ServerConfigReader();
+        try {
+            reader.getServerConfigurations(NUMBER_FORMAT_EXCEPTION_PATH);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertEquals("For input string: \"string\"", e.getLocalizedMessage());
+        }
+    }
+}

--- a/server/src/test/java/io/julian/server/components/ConfigurationTest.java
+++ b/server/src/test/java/io/julian/server/components/ConfigurationTest.java
@@ -10,6 +10,7 @@ public class ConfigurationTest {
         Assert.assertEquals(Configuration.DEFAULT_SERVER_PORT, configuration.getServerPort());
         Assert.assertEquals(Configuration.DEFAULT_SERVER_HOST, configuration.getServerHost());
         Assert.assertEquals(Configuration.DEFAULT_OPENAPI_SPEC_LOCATION, configuration.getOpenapiSpecLocation());
+        Assert.assertEquals(Configuration.DEFAULT_SERVER_CONFIGURATION_LOCATION, configuration.getServerConfigurationLocation());
         Assert.assertEquals("", configuration.getJarFilePath());
         Assert.assertEquals("", configuration.getPackageName());
         Assert.assertEquals(Configuration.DEFAULT_DOES_PROCESS_REQUEST, configuration.doesProcessRequest());
@@ -21,12 +22,14 @@ public class ConfigurationTest {
         Assert.assertEquals(Configuration.DEFAULT_SERVER_PORT, configuration.getServerPort());
         Assert.assertEquals(Configuration.DEFAULT_SERVER_HOST, configuration.getServerHost());
         Assert.assertEquals(Configuration.DEFAULT_OPENAPI_SPEC_LOCATION, configuration.getOpenapiSpecLocation());
+        Assert.assertEquals(Configuration.DEFAULT_SERVER_CONFIGURATION_LOCATION, configuration.getServerConfigurationLocation());
         Assert.assertEquals("", configuration.getJarFilePath());
         Assert.assertEquals("", configuration.getPackageName());
 
         String host = "new-host";
         int port = 93423;
         String openApiPath = "random/path";
+        String serverConfigurationPath = "server/config/path";
         String jarFilePath = "jar.file";
         String packageName = "io.package";
         boolean doesProcessRequest = false;
@@ -34,6 +37,7 @@ public class ConfigurationTest {
         configuration.setServerHost(host);
         configuration.setServerPort(port);
         configuration.setOpenapiSpecLocation(openApiPath);
+        configuration.setServerConfigurationLocation(serverConfigurationPath);
         configuration.setJarFilePath(jarFilePath);
         configuration.setPackageName(packageName);
         configuration.setDoesProcessRequest(doesProcessRequest);
@@ -41,6 +45,7 @@ public class ConfigurationTest {
         Assert.assertEquals(port, configuration.getServerPort());
         Assert.assertEquals(host, configuration.getServerHost());
         Assert.assertEquals(openApiPath, configuration.getOpenapiSpecLocation());
+        Assert.assertEquals(serverConfigurationPath, configuration.getServerConfigurationLocation());
         Assert.assertEquals(jarFilePath, configuration.getJarFilePath());
         Assert.assertEquals(packageName, configuration.getPackageName());
         Assert.assertEquals(doesProcessRequest, configuration.doesProcessRequest());

--- a/server/src/test/resources/NumberFormatExceptionConfiguration.txt
+++ b/server/src/test/resources/NumberFormatExceptionConfiguration.txt
@@ -1,0 +1,2 @@
+localhost:string
+localhost:8989

--- a/server/src/test/resources/validServerConfiguration.txt
+++ b/server/src/test/resources/validServerConfiguration.txt
@@ -1,0 +1,2 @@
+localhost:9898
+localhost:8989

--- a/zookeeper/src/test/java/io/julian/zookeeper/AbstractServerBase.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/AbstractServerBase.java
@@ -57,10 +57,11 @@ public abstract class AbstractServerBase {
     }
 
     protected RegistryManager createTestRegistryManager() {
-        RegistryManager manager = new RegistryManager();
+        RegistryManager manager = new RegistryManager(new Configuration());
         manager.registerServer(Configuration.DEFAULT_SERVER_HOST, Configuration.DEFAULT_SERVER_PORT);
         return manager;
     }
+
 
     protected ServerClient createServerClient() {
         return new ServerClient(this.vertx);

--- a/zookeeper/src/test/java/io/julian/zookeeper/election/CandidateInformationRegistryTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/election/CandidateInformationRegistryTest.java
@@ -1,6 +1,7 @@
 package io.julian.zookeeper.election;
 
 import io.julian.server.api.client.RegistryManager;
+import io.julian.server.components.Configuration;
 import io.julian.server.models.control.ServerConfiguration;
 import io.julian.zookeeper.models.CandidateInformation;
 import org.junit.Assert;
@@ -81,7 +82,7 @@ public class CandidateInformationRegistryTest {
     @Test
     public void TestIsRegistryFilled() {
         CandidateInformationRegistry registry = new CandidateInformationRegistry();
-        RegistryManager manager = new RegistryManager();
+        RegistryManager manager = new RegistryManager(new Configuration());
 
         Assert.assertFalse(registry.isRegistryFilled(manager));
 

--- a/zookeeper/src/test/java/io/julian/zookeeper/election/LeadershipElectionHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/election/LeadershipElectionHandlerTest.java
@@ -34,7 +34,7 @@ public class LeadershipElectionHandlerTest extends AbstractServerBase {
     @Test
     public void TestUpdateLeaderCorrectlyUpdatesServerToLeader() {
         Controller controller = new Controller(new Configuration());
-        RegistryManager manager = new RegistryManager();
+        RegistryManager manager = new RegistryManager(new Configuration());
 
 
         LeadershipElectionHandler handler = createTestHandler();
@@ -52,7 +52,7 @@ public class LeadershipElectionHandlerTest extends AbstractServerBase {
     @Test
     public void TestUpdateLeaderCorrectlyUpdatesServerToFollower() {
         Controller controller = new Controller(new Configuration());
-        RegistryManager manager = new RegistryManager();
+        RegistryManager manager = new RegistryManager(new Configuration());
 
         LeadershipElectionHandler handler = createTestHandler();
         manager.registerServer(HOST, PORT);


### PR DESCRIPTION
Added the ability for the server to read files from a file and register the other server. This was done via adding ServerConfigReader class. There is a new method in RegistryManager's init which runs to register all servers.

Closes: #35 

Signed-off-by: Julian Goh <juliangohsl@gmail.com>
