### PR TITLE
Differentiated log files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,8 @@ CLIENT_GENERATED_FOLDER="client/src/main/resources/generated"
 
 SERVER_JAR_NAME="server-1.0-SNAPSHOT-jar-with-dependencies.jar"
 SERVER_OPENAPI_YAML="server/src/main/resources/ServerEndpoints.yaml"
-
+STANDARD_LOG4J2_FILE="logger/standard-log4j2.xml"
+FILE_LOG4J2_FILE="logger/file-out-log4j2.xml"
 mvn clean package -DskipTests
 
 docker build . -t "${BASE_IMAGE}:${IMAGE_TAG}" -f dockerfiles/Dockerfile.base
@@ -19,10 +20,12 @@ docker build . -t "${CLIENT_IMAGE}:${IMAGE_TAG}" \
     --build-arg BASE_IMAGE="${BASE_IMAGE}"  \
     --build-arg JAR_NAME="${CLIENT_JAR_NAME}" \
     --build-arg CLIENT_GENERATED_FOLDER="${CLIENT_GENERATED_FOLDER}" \
+    --build-arg LOG4J2_FILE="${FILE_LOG4J2_FILE}" \
     -f dockerfiles/Dockerfile.client
 
 docker build . -t "${SERVER_IMAGE}:${IMAGE_TAG}" \
     --build-arg BASE_IMAGE="${BASE_IMAGE}"  \
     --build-arg JAR_NAME="${SERVER_JAR_NAME}" \
     --build-arg SERVER_OPENAPI_YAML="${SERVER_OPENAPI_YAML}" \
+    --build-arg LOG4J2_FILE="${STANDARD_LOG4J2_FILE}" \
     -f dockerfiles/Dockerfile.server

--- a/dockerfiles/Dockerfile.client
+++ b/dockerfiles/Dockerfile.client
@@ -3,17 +3,23 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}:latest
 
 ARG JAR_NAME
+ARG LOG4J2_FILE
+ENV LOG4J2_LOCATION="/resources/log4j2.xml"
+
 COPY client/target/${JAR_NAME} ${JAR_NAME}
+COPY ${LOG4J2_FILE} ${LOG4J2_LOCATION}
 
 ENV JAR_NAME=${JAR_NAME}
 ENV OPERATIONS_FILE_PATH="/resources/operations"
 ENV MESSAGE_FILE_PATH="/resources/messages"
 ENV REPORT_FILE_PATH="/resources/report"
+ENV LOG_PATH="/resources/logs"
 
 ARG CLIENT_GENERATED_FOLDER
 COPY ${CLIENT_GENERATED_FOLDER}/operations ${OPERATIONS_FILE_PATH}
 COPY ${CLIENT_GENERATED_FOLDER}/messages ${MESSAGE_FILE_PATH}
+COPY dockerfiles/client-run.sh /client-run.sh
 
-VOLUME [ ${REPORT_FILE_PATH} ]
+VOLUME [ ${REPORT_FILE_PATH} , ${LOG_PATH}]
 
-CMD java -jar ${JAR_NAME}
+ENTRYPOINT ["/bin/sh", "-c", "./client-run.sh "]

--- a/dockerfiles/Dockerfile.server
+++ b/dockerfiles/Dockerfile.server
@@ -10,10 +10,14 @@ ENV SETTINGS_FOLDER="/settings"
 COPY server/target/${JAR_NAME} ${JAR_NAME}
 
 ARG SERVER_OPENAPI_YAML
+ARG LOG4J2_FILE
 ENV OPENAPI_SPEC_LOCATION="/resources/ServerEndpoints.yaml"
+ENV LOG4J2_LOCATION="/resources/log4j2.xml"
 
 COPY ${SERVER_OPENAPI_YAML} ${OPENAPI_SPEC_LOCATION}
+COPY ${LOG4J2_FILE} ${LOG4J2_LOCATION}
+COPY dockerfiles/server-run.sh /server-run.sh
 
-VOLUME [ ${JAR_FILE_FOLDER}, ${SETTINGS_FOLDER} ]
+VOLUME [ ${JAR_FILE_FOLDER} , ${SETTINGS_FOLDER} ]
 
-CMD java -jar ${JAR_NAME}
+ENTRYPOINT ["/bin/sh", "-c", "./server-run.sh "]

--- a/dockerfiles/client-run.sh
+++ b/dockerfiles/client-run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+java -Dlog4j.configurationFile="/resources/log4j2.xml" -jar "${JAR_NAME}"

--- a/dockerfiles/server-run.sh
+++ b/dockerfiles/server-run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+java -Dlog4j.configurationFile="/resources/log4j2.xml" -jar "${JAR_NAME}"

--- a/logger/file-out-log4j2.xml
+++ b/logger/file-out-log4j2.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="info">
     <Appenders>
-        <Console name="STDOUT" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d %-5p %C{1}.%M: (%F:%L) - %m%n"/>
-        </Console>
-        <RollingFile name="FILE" append="false" filePattern="/Users/juliangoh/Projects/src/java/DistributedBlackboxOperations/logs/log'-%d{MM-dd-yyyy}">
+        <RollingFile name="FILE" append="false" filePattern="/resources/logs/client-logs">
             <PatternLayout pattern="%d %-5p %C{1}.%M: (%F:%L) - %m%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy />
@@ -13,7 +10,7 @@
     </Appenders>
     <Loggers>
         <Root level="info">
-            <AppenderRef ref="STDOUT"/>
+            <AppenderRef ref="FILE"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/logger/standard-log4j2.xml
+++ b/logger/standard-log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="info">
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %-5p %C{1}.%M: (%F:%L) - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/run-client.sh
+++ b/run-client.sh
@@ -7,6 +7,8 @@ CLIENT_IMAGE="${PROJECT_NAME}-client"
 IMAGE_TAG="latest"
 CONTAINER_REPORT_PATH="/resources/report"
 REPORT_FOLDER="${WORKDIR}/generated/report"
+CONTAINER_LOGS_FOLDER="/resources/logs"
+LOGS_FOLDER="${WORKDIR}/generated/logs"
 DEFAULT_SERVER_PORT="8888"
 
 echo "Usage: use this script to run a client after running ./build.sh to build the necessary docker image"
@@ -18,5 +20,6 @@ echo "Client will connect to server on port ${SERVER_PORT}"
 docker run -it \
     --network="host" \
     -v "$REPORT_FOLDER":${CONTAINER_REPORT_PATH} \
+    -v "$LOGS_FOLDER":${CONTAINER_LOGS_FOLDER} \
     -e SERVER_PORT="${SERVER_PORT}" \
     "${CLIENT_IMAGE}:${IMAGE_TAG}"


### PR DESCRIPTION
Differentiated the client and the server log files so now the client will produce logs to a file and the server will produce logs to terminal. The file is volume mounted so we don't need to pull logs from a file. Also introduced an entrypoint script so that we can have full control of java args

Closes: #19

Signed-off-by: Julian Goh <juliangohsl@gmail.com>