### PR TITLE
feat: Add cAdvisor setup

### DIFF
--- a/test-run/cAdvisor/setup.sh
+++ b/test-run/cAdvisor/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+docker run \
+  --volume=/:/rootfs:ro \
+  --volume=/var/run/docker.sock:/var/run/docker.sock:rw \
+  --volume=/sys:/sys:ro \
+  --volume=/var/lib/docker/:/var/lib/docker:ro \
+  --publish=8080:8080 \
+  --detach=true \
+  --name=cadvisor \
+  google/cadvisor:latest
+
+open http://localhost:8080

--- a/test-run/cAdvisor/teardown.sh
+++ b/test-run/cAdvisor/teardown.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker stop cadvisor || true && docker rm cadvisor || true

--- a/test-run/zookeeper/kickoff.sh
+++ b/test-run/zookeeper/kickoff.sh
@@ -2,6 +2,7 @@
 
 CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
+"$CWD/../cAdvisor/setup.sh"
 "$CWD/setup.sh"
 echo "Waiting 5 seconds to setup servers"
 sleep 5

--- a/test-run/zookeeper/setup.sh
+++ b/test-run/zookeeper/setup.sh
@@ -9,6 +9,13 @@ JAR_NAME="zookeeper-1.0-SNAPSHOT-jar-with-dependencies.jar"
 SERVER_LIST_FILE="settings/server-list.txt"
 SERVER_LIST_CONTENTS=""
 
+GREP_FOR_CADVISOR_HOST=$(cat "$CWD/settings/server-ports.txt" | grep 8080)
+
+if [ -n "$GREP_FOR_CADVISOR_HOST" ]; then
+  echo "Server Ports can't contain 8080 as cAdvisor is created on that port"
+  exit 1
+fi
+
 while IFS= read -r PORT
 do
   DOCKER_COMPOSE_FILE="$DOCKER_COMPOSE_FILE

--- a/test-run/zookeeper/teardown.sh
+++ b/test-run/zookeeper/teardown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 DOCKER_COMPOSE_FILE_NAME="$CWD/docker-compose.yaml"
-
+"$CWD/../cAdvisor/teardown.sh"
 docker-compose -f "$DOCKER_COMPOSE_FILE_NAME" down


### PR DESCRIPTION
Created a cAdvisor setup and teardown script which will allow us to automatically monitor the pods performance.
Also added the necessary checks to ensure that zookeeper server isn't initialised on cAdvisor port.

Closes: #52

Signed-off-by: Julian Goh <juliangohsl@gmail.com>