### PR TITLE
feat: metrics collector client

### DIFF
--- a/metrics-collector/src/test/java/io/julian/metrics/collector/server/handlers/ReportHandlerTest.java
+++ b/metrics-collector/src/test/java/io/julian/metrics/collector/server/handlers/ReportHandlerTest.java
@@ -15,8 +15,10 @@ public class ReportHandlerTest extends AbstractHandlerTest {
         TestClient client = createTestClient();
 
         client.successfulCreateReport(context, ReportCreator.GENERAL_STATISTIC_FILTER_NAME);
-        ReportCreatorTest.assertReportFileExists(vertx, context, true);
-        ReportCreatorTest.deleteReportFile(vertx, context);
+        vertx.setTimer(2000, res -> {
+            ReportCreatorTest.assertReportFileExists(vertx, context, true);
+            ReportCreatorTest.deleteReportFile(vertx, context);
+        });
         server.tearDownServer(context);
     }
 

--- a/metrics-collector/src/test/java/io/julian/metrics/collector/server/handlers/ReportHandlerTest.java
+++ b/metrics-collector/src/test/java/io/julian/metrics/collector/server/handlers/ReportHandlerTest.java
@@ -15,10 +15,8 @@ public class ReportHandlerTest extends AbstractHandlerTest {
         TestClient client = createTestClient();
 
         client.successfulCreateReport(context, ReportCreator.GENERAL_STATISTIC_FILTER_NAME);
-        vertx.setTimer(2000, res -> {
-            ReportCreatorTest.assertReportFileExists(vertx, context, true);
-            ReportCreatorTest.deleteReportFile(vertx, context);
-        });
+        ReportCreatorTest.assertReportFileExists(vertx, context, true);
+        ReportCreatorTest.deleteReportFile(vertx, context);
         server.tearDownServer(context);
     }
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -65,6 +65,13 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+
+        <!-- Internal Dependency -->
+        <dependency>
+            <groupId>io.julian</groupId>
+            <artifactId>metrics-collector</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/src/main/java/io/julian/server/api/DistributedAlgorithm.java
+++ b/server/src/main/java/io/julian/server/api/DistributedAlgorithm.java
@@ -25,7 +25,7 @@ public abstract class DistributedAlgorithm {
     public DistributedAlgorithm(final Controller controller, final MessageStore messageStore, final Vertx vertx) {
         this.controller = controller;
         this.messageStore = messageStore;
-        this.client = new ServerClient(vertx);
+        this.client = new ServerClient(vertx, controller.getConfiguration());
         this.registryManager = new RegistryManager(controller.getConfiguration());
         this.vertx = vertx;
     }

--- a/server/src/main/java/io/julian/server/api/client/ServerClient.java
+++ b/server/src/main/java/io/julian/server/api/client/ServerClient.java
@@ -138,6 +138,33 @@ public class ServerClient {
         return log.traceExit(res.future());
     }
 
+    public Future<Void> createReport() {
+        log.traceEntry();
+        Promise<Void> res = Promise.promise();
+        log.info("Sending message to create message in metrics collector");
+        client
+            .post(configuration.getMetricsCollectorPort(), configuration.getServerHost(), REPORT_URI)
+            .send(ar -> {
+                if (ar.succeeded()) {
+                    if (ar.result().statusCode() == 200) {
+                        log.info("Successfully created report in metrics collector");
+                        res.complete();
+                    } else {
+                        ErrorResponse response = ErrorResponse.fromJson(ar.result().bodyAsJsonObject());
+                        log.info("Failed to created report in metrics collector");
+                        log.error(response.getException());
+                        res.fail(response.getException());
+                    }
+                } else {
+                    ErrorResponse response = new ErrorResponse(500, ar.cause());
+                    log.info("Failed to created report in metrics collector");
+                    log.error(response.getException());
+                    res.fail(response.getException());
+                }
+            });
+        return log.traceExit(res.future());
+    }
+
     public WebClient getWebClient() {
         log.traceEntry();
         return log.traceExit(client);

--- a/server/src/main/java/io/julian/server/components/Configuration.java
+++ b/server/src/main/java/io/julian/server/components/Configuration.java
@@ -25,6 +25,14 @@ public class Configuration {
     public static final int DEFAULT_SERVER_PORT = 8888;
     private int port;
 
+    public static final String METRICS_COLLECTOR_HOST_ENV = "METRICS_COLLECTOR_HOST";
+    public static final String DEFAULT_METRICS_COLLECTOR_HOST = "localhost";
+    private String metricsCollectorHost;
+
+    public static final String METRICS_COLLECTOR_PORT_ENV = "METRICS_COLLECTOR_PORT";
+    public static final int DEFAULT_METRICS_COLLECTOR_PORT = 9090;
+    private int metricsCollectorPort;
+
     public static final String DOES_PROCESS_REQUEST_ENV = "DOES_PROCESS_REQUEST";
     public static final boolean DEFAULT_DOES_PROCESS_REQUEST = true;
     private boolean doesProcessRequest;
@@ -39,6 +47,8 @@ public class Configuration {
         this.serverConfigurationLocation = getOrDefault(SERVER_CONFIGURATION_LOCATION, DEFAULT_SERVER_CONFIGURATION_LOCATION);
         this.host = getOrDefault(SERVER_HOST_ENV, DEFAULT_SERVER_HOST);
         this.port = getOrDefault(SERVER_PORT_ENV, DEFAULT_SERVER_PORT);
+        this.metricsCollectorHost = getOrDefault(METRICS_COLLECTOR_HOST_ENV, DEFAULT_METRICS_COLLECTOR_HOST);
+        this.metricsCollectorPort = getOrDefault(METRICS_COLLECTOR_PORT_ENV, DEFAULT_METRICS_COLLECTOR_PORT);
         this.jarFilePath = getOrDefault(JAR_FILE_PATH_ENV, "");
         this.packageName = getOrDefault(PACKAGE_NAME_ENV, "");
         this.doesProcessRequest = getOrDefault(DOES_PROCESS_REQUEST_ENV, DEFAULT_DOES_PROCESS_REQUEST);
@@ -63,6 +73,28 @@ public class Configuration {
     public void setServerHost(final String host) {
         log.traceEntry(() -> host);
         this.host = host;
+        log.traceExit();
+    }
+
+    public int getMetricsCollectorPort() {
+        log.traceEntry();
+        return log.traceExit(metricsCollectorPort);
+    }
+
+    public void setMetricsCollectorPort(final int metricsCollectorPort) {
+        log.traceEntry(() -> metricsCollectorPort);
+        this.metricsCollectorPort = metricsCollectorPort;
+        log.traceExit();
+    }
+
+    public String getMetricsCollectorHost() {
+        log.traceEntry();
+        return log.traceExit(metricsCollectorHost);
+    }
+
+    public void setMetricsCollectorHost(final String metricsCollectorHost) {
+        log.traceEntry(() -> metricsCollectorHost);
+        this.metricsCollectorHost = metricsCollectorHost;
         log.traceExit();
     }
 

--- a/server/src/test/java/io/julian/server/api/client/ServerClientTest.java
+++ b/server/src/test/java/io/julian/server/api/client/ServerClientTest.java
@@ -1,12 +1,15 @@
 package io.julian.server.api.client;
 
+import io.julian.metrics.collector.models.TrackedMessage;
 import io.julian.server.components.Configuration;
+import io.julian.server.endpoints.TestMetricsCollector;
 import io.julian.server.endpoints.control.AbstractServerHandlerTest;
 import io.julian.server.models.control.ServerConfiguration;
 import io.julian.server.models.coordination.CoordinationMessage;
 import io.julian.server.models.response.LabelResponse;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static io.julian.server.models.coordination.CoordinationMessageTest.JSON;
@@ -19,14 +22,14 @@ public class ServerClientTest extends AbstractServerHandlerTest {
     @Test
     public void TestServerClientSuccessfullySendCoordinateMessage(final TestContext context) {
         setUpApiServer(context);
-        ServerClient client = new ServerClient(vertx);
+        ServerClient client = new ServerClient(vertx, new Configuration());
         client.sendCoordinateMessageToServer(OTHER_SERVER_CONFIGURATION, CoordinationMessage.fromJson(JSON))
             .onComplete(context.asyncAssertSuccess(context::assertNull));
     }
 
     @Test
     public void TestServerClientUnsuccessfullySendCoordinateMessageWhenNoServer(final TestContext context) {
-        ServerClient client = new ServerClient(vertx);
+        ServerClient client = new ServerClient(vertx, new Configuration());
         client.sendCoordinateMessageToServer(OTHER_SERVER_CONFIGURATION, CoordinationMessage.fromJson(JSON))
             .onComplete(context.asyncAssertFailure(res -> context.assertEquals(
                 String.format(connectionRefusedFormat, OTHER_SERVER_CONFIGURATION.getHost(), OTHER_SERVER_CONFIGURATION.getPort()), res.getMessage())));
@@ -36,7 +39,7 @@ public class ServerClientTest extends AbstractServerHandlerTest {
     public void TestServerClientSuccessfullySendLabel(final TestContext context) {
         setUpApiServer(context);
         String newLabel = "label";
-        ServerClient client = new ServerClient(vertx);
+        ServerClient client = new ServerClient(vertx, new Configuration());
         ServerConfiguration originalServerConfig = new ServerConfiguration(OTHER_SERVER_CONFIGURATION.getHost(), OTHER_SERVER_CONFIGURATION.getPort());
         context.assertNotEquals(newLabel, originalServerConfig.getLabel());
         Async async = context.async();
@@ -54,7 +57,7 @@ public class ServerClientTest extends AbstractServerHandlerTest {
         setUpApiServer(context);
         String newLabel = "label";
         server.getController().setLabel(newLabel);
-        ServerClient client = new ServerClient(vertx);
+        ServerClient client = new ServerClient(vertx, new Configuration());
         ServerConfiguration originalServerConfig = new ServerConfiguration(OTHER_SERVER_CONFIGURATION.getHost(), OTHER_SERVER_CONFIGURATION.getPort());
 
         context.assertNotEquals(newLabel, originalServerConfig.getLabel());
@@ -71,7 +74,7 @@ public class ServerClientTest extends AbstractServerHandlerTest {
 
     @Test
     public void TestServerClientUnsuccessfullyGetCoordinateMessageWhenNoServer(final TestContext context) {
-        ServerClient client = new ServerClient(vertx);
+        ServerClient client = new ServerClient(vertx, new Configuration());
         client.getServerLabel(OTHER_SERVER_CONFIGURATION)
             .onComplete(context.asyncAssertFailure(res -> context.assertEquals(
                 String.format(connectionRefusedFormat, OTHER_SERVER_CONFIGURATION.getHost(), OTHER_SERVER_CONFIGURATION.getPort()), res.getMessage())));
@@ -79,9 +82,53 @@ public class ServerClientTest extends AbstractServerHandlerTest {
 
     @Test
     public void TestServerClientCanNotSendLabelWhenNoServer(final TestContext context) {
-        ServerClient client = new ServerClient(vertx);
+        ServerClient client = new ServerClient(vertx, new Configuration());
         client.sendLabelToServer(OTHER_SERVER_CONFIGURATION, "random-label")
             .onComplete(context.asyncAssertFailure(res -> context.assertEquals(
                 String.format(connectionRefusedFormat, OTHER_SERVER_CONFIGURATION.getHost(), OTHER_SERVER_CONFIGURATION.getPort()), res.getMessage())));
+    }
+
+    @Test
+    public void TestServerClientCanSendMessageToMetricsCollector(final TestContext context) {
+        TestMetricsCollector collector = createCollector(context);
+        ServerClient client = new ServerClient(vertx, new Configuration());
+        Async async = context.async();
+        client.trackMessage(new TrackedMessage(200, "random-id", 10.4f))
+            .onComplete(context.asyncAssertSuccess(res -> async.complete()));
+        async.awaitSuccess();
+        collector.assertHasNumberOfTrackedMessages(1);
+        collector.tearDownServer(context);
+    }
+
+    @Test
+    public void TestServerClientFailsToSendMessageToMetricsCollector(final TestContext context) {
+        ServerClient client = new ServerClient(vertx, new Configuration());
+        Async async = context.async();
+        client.trackMessage(new TrackedMessage(200, "random-id", 10.4f))
+            .onComplete(context.asyncAssertFailure(cause -> {
+                Assert.assertEquals(TestMetricsCollector.FAILED_TO_CONNECT, cause.getMessage());
+                async.complete();
+            }));
+        async.awaitSuccess();
+    }
+
+    @Test
+    public void TestServerClientFailsToSendMessageWhenMissingFiledToMetricsCollector(final TestContext context) {
+        TestMetricsCollector collector = createCollector(context);
+        ServerClient client = new ServerClient(vertx, new Configuration());
+        Async async = context.async();
+        client.trackMessage(new TrackedMessage(200, null, 10.4f))
+            .onComplete(context.asyncAssertFailure(cause -> {
+                Assert.assertEquals("$.messageId: null found, string expected", cause.getMessage());
+                async.complete();
+            }));
+        async.awaitSuccess();
+        collector.tearDownServer(context);
+    }
+
+    private TestMetricsCollector createCollector(final TestContext context) {
+        TestMetricsCollector collector = new TestMetricsCollector();
+        collector.setUpMetricsCollector(context, vertx);
+        return collector;
     }
 }

--- a/server/src/test/java/io/julian/server/components/ConfigurationTest.java
+++ b/server/src/test/java/io/julian/server/components/ConfigurationTest.java
@@ -9,6 +9,8 @@ public class ConfigurationTest {
         Configuration configuration = new Configuration();
         Assert.assertEquals(Configuration.DEFAULT_SERVER_PORT, configuration.getServerPort());
         Assert.assertEquals(Configuration.DEFAULT_SERVER_HOST, configuration.getServerHost());
+        Assert.assertEquals(Configuration.DEFAULT_METRICS_COLLECTOR_PORT, configuration.getMetricsCollectorPort());
+        Assert.assertEquals(Configuration.DEFAULT_METRICS_COLLECTOR_HOST, configuration.getMetricsCollectorHost());
         Assert.assertEquals(Configuration.DEFAULT_OPENAPI_SPEC_LOCATION, configuration.getOpenapiSpecLocation());
         Assert.assertEquals(Configuration.DEFAULT_SERVER_CONFIGURATION_LOCATION, configuration.getServerConfigurationLocation());
         Assert.assertEquals("", configuration.getJarFilePath());
@@ -28,26 +30,32 @@ public class ConfigurationTest {
 
         String host = "new-host";
         int port = 93423;
+        String metricsCollectorHost = "new-metrics-host";
+        int metricsCollectorPort = 1;
+
         String openApiPath = "random/path";
         String serverConfigurationPath = "server/config/path";
         String jarFilePath = "jar.file";
         String packageName = "io.package";
-        boolean doesProcessRequest = false;
 
         configuration.setServerHost(host);
         configuration.setServerPort(port);
+        configuration.setMetricsCollectorHost(metricsCollectorHost);
+        configuration.setMetricsCollectorPort(metricsCollectorPort);
         configuration.setOpenapiSpecLocation(openApiPath);
         configuration.setServerConfigurationLocation(serverConfigurationPath);
         configuration.setJarFilePath(jarFilePath);
         configuration.setPackageName(packageName);
-        configuration.setDoesProcessRequest(doesProcessRequest);
+        configuration.setDoesProcessRequest(false);
 
         Assert.assertEquals(port, configuration.getServerPort());
         Assert.assertEquals(host, configuration.getServerHost());
+        Assert.assertEquals(metricsCollectorPort, configuration.getMetricsCollectorPort());
+        Assert.assertEquals(metricsCollectorHost, configuration.getMetricsCollectorHost());
         Assert.assertEquals(openApiPath, configuration.getOpenapiSpecLocation());
         Assert.assertEquals(serverConfigurationPath, configuration.getServerConfigurationLocation());
         Assert.assertEquals(jarFilePath, configuration.getJarFilePath());
         Assert.assertEquals(packageName, configuration.getPackageName());
-        Assert.assertEquals(doesProcessRequest, configuration.doesProcessRequest());
+        Assert.assertFalse(configuration.doesProcessRequest());
     }
 }

--- a/server/src/test/java/io/julian/server/endpoints/TestMetricsCollector.java
+++ b/server/src/test/java/io/julian/server/endpoints/TestMetricsCollector.java
@@ -1,5 +1,6 @@
 package io.julian.server.endpoints;
 
+import io.julian.metrics.collector.report.ReportCreator;
 import io.julian.metrics.collector.server.Configuration;
 import io.julian.metrics.collector.server.Server;
 import io.vertx.core.Vertx;
@@ -13,13 +14,29 @@ public class TestMetricsCollector {
     public static final String HOST = Configuration.DEFAULT_SERVER_HOST;
     public static final int PORT = Configuration.DEFAULT_SERVER_PORT;
     public static final String OPENAPI_SPEC_LOCATION = String.format("%s/../metrics-collector/src/main/resources/metrics-collector-endpoints.yaml", System.getProperty("user.dir"));
+    public static final String REPORT_LOCATION = String.format("%s/../metrics-collector/src/test/resources", System.getProperty("user.dir"));
+    public static final String REPORT_FILE_PATH = String.format("%s/%s", REPORT_LOCATION, ReportCreator.REPORT_FILE_NAME);
     public static final String FAILED_TO_CONNECT = String.format("Connection refused: %s/127.0.0.1:%d", HOST, PORT);
+    public static final String INVALID_REPORT_LOCATION = "/invalid-path";
+    public static final String INVALID_REPORT_FILE_PATH = String.format("%s/%s", INVALID_REPORT_LOCATION, ReportCreator.REPORT_FILE_NAME);
 
     public Server metricsCollector;
     public HttpServer api;
 
     public void setUpMetricsCollector(final TestContext context, final Vertx vertx) {
-        metricsCollector = new Server(new Configuration());
+        Configuration configuration = new Configuration();
+        configuration.setReportPath(REPORT_LOCATION);
+        setUpMetricsCollector(context, configuration, vertx);
+    }
+
+    public void setUpMetricsCollectorWithWrongReportPath(final TestContext context, final Vertx vertx) {
+        Configuration configuration = new Configuration();
+        configuration.setReportPath(INVALID_REPORT_LOCATION);
+        setUpMetricsCollector(context, configuration, vertx);
+    }
+
+    public void setUpMetricsCollector(final TestContext context, final Configuration configuration, final Vertx vertx) {
+        metricsCollector = new Server(configuration);
         api = vertx.createHttpServer(new HttpServerOptions()
             .setPort(PORT)
             .setHost(HOST));
@@ -42,5 +59,24 @@ public class TestMetricsCollector {
 
     public void assertHasNumberOfTrackedMessages(final int messages) {
         Assert.assertEquals(messages, metricsCollector.getTracker().getStatuses().size());
+    }
+
+    public void assertFileReportDoesExists(final TestContext context, final Vertx vertx, final boolean doesExist) {
+        Async async = context.async();
+        vertx.fileSystem().exists(REPORT_FILE_PATH, ar -> {
+            Assert.assertEquals(doesExist, ar.result());
+            async.complete();
+        });
+        async.awaitSuccess();
+    }
+
+    public void deleteReportFile(final TestContext context, final Vertx vertx) {
+        Async async = context.async();
+        vertx.fileSystem().exists(REPORT_FILE_PATH, doesExist -> {
+            if (doesExist.result()) {
+                vertx.fileSystem().delete(REPORT_FILE_PATH, ar -> async.complete());
+            }
+        });
+        async.awaitSuccess();
     }
 }

--- a/server/src/test/java/io/julian/server/endpoints/TestMetricsCollector.java
+++ b/server/src/test/java/io/julian/server/endpoints/TestMetricsCollector.java
@@ -14,7 +14,7 @@ public class TestMetricsCollector {
     public static final String HOST = Configuration.DEFAULT_SERVER_HOST;
     public static final int PORT = Configuration.DEFAULT_SERVER_PORT;
     public static final String OPENAPI_SPEC_LOCATION = String.format("%s/../metrics-collector/src/main/resources/metrics-collector-endpoints.yaml", System.getProperty("user.dir"));
-    public static final String REPORT_LOCATION = String.format("%s/src/test/resources", System.getProperty("user.dir"));
+    public static final String REPORT_LOCATION = String.format("%s/../metrics-collector/src/test/resources", System.getProperty("user.dir"));
     public static final String REPORT_FILE_PATH = String.format("%s/%s", REPORT_LOCATION, ReportCreator.REPORT_FILE_NAME);
     public static final String FAILED_TO_CONNECT = String.format("Connection refused: %s/127.0.0.1:%d", HOST, PORT);
     public static final String INVALID_REPORT_LOCATION = "/invalid-path";

--- a/server/src/test/java/io/julian/server/endpoints/TestMetricsCollector.java
+++ b/server/src/test/java/io/julian/server/endpoints/TestMetricsCollector.java
@@ -14,7 +14,7 @@ public class TestMetricsCollector {
     public static final String HOST = Configuration.DEFAULT_SERVER_HOST;
     public static final int PORT = Configuration.DEFAULT_SERVER_PORT;
     public static final String OPENAPI_SPEC_LOCATION = String.format("%s/../metrics-collector/src/main/resources/metrics-collector-endpoints.yaml", System.getProperty("user.dir"));
-    public static final String REPORT_LOCATION = String.format("%s/../metrics-collector/src/test/resources", System.getProperty("user.dir"));
+    public static final String REPORT_LOCATION = String.format("%s/src/test/resources", System.getProperty("user.dir"));
     public static final String REPORT_FILE_PATH = String.format("%s/%s", REPORT_LOCATION, ReportCreator.REPORT_FILE_NAME);
     public static final String FAILED_TO_CONNECT = String.format("Connection refused: %s/127.0.0.1:%d", HOST, PORT);
     public static final String INVALID_REPORT_LOCATION = "/invalid-path";

--- a/server/src/test/java/io/julian/server/endpoints/TestMetricsCollector.java
+++ b/server/src/test/java/io/julian/server/endpoints/TestMetricsCollector.java
@@ -1,0 +1,46 @@
+package io.julian.server.endpoints;
+
+import io.julian.metrics.collector.server.Configuration;
+import io.julian.metrics.collector.server.Server;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Assert;
+
+public class TestMetricsCollector {
+    public static final String HOST = Configuration.DEFAULT_SERVER_HOST;
+    public static final int PORT = Configuration.DEFAULT_SERVER_PORT;
+    public static final String OPENAPI_SPEC_LOCATION = String.format("%s/../metrics-collector/src/main/resources/metrics-collector-endpoints.yaml", System.getProperty("user.dir"));
+    public static final String FAILED_TO_CONNECT = String.format("Connection refused: %s/127.0.0.1:%d", HOST, PORT);
+
+    public Server metricsCollector;
+    public HttpServer api;
+
+    public void setUpMetricsCollector(final TestContext context, final Vertx vertx) {
+        metricsCollector = new Server(new Configuration());
+        api = vertx.createHttpServer(new HttpServerOptions()
+            .setPort(PORT)
+            .setHost(HOST));
+
+        Async async = context.async();
+        metricsCollector.startServer(vertx, OPENAPI_SPEC_LOCATION)
+            .onComplete(context.asyncAssertSuccess(compositeFuture -> api.requestHandler(metricsCollector.getRouterFactory().getRouter()).listen(ar -> {
+                context.assertTrue(ar.succeeded());
+                async.complete();
+            })));
+        async.awaitSuccess();
+    }
+
+    public void tearDownServer(final TestContext context) {
+        metricsCollector = null;
+        Async async = context.async();
+        api.close(context.asyncAssertSuccess(v ->  async.complete()));
+        async.awaitSuccess();
+    }
+
+    public void assertHasNumberOfTrackedMessages(final int messages) {
+        Assert.assertEquals(messages, metricsCollector.getTracker().getStatuses().size());
+    }
+}

--- a/zookeeper/src/test/java/io/julian/zookeeper/AbstractServerBase.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/AbstractServerBase.java
@@ -63,7 +63,7 @@ public abstract class AbstractServerBase {
     }
 
     protected ServerClient createServerClient() {
-        return new ServerClient(this.vertx);
+        return new ServerClient(this.vertx, new Configuration());
     }
 
     protected TestClient createTestClient() {


### PR DESCRIPTION
Added the ability to connect to the metrics collector to track messages and create the report in the server client. Added the relevant tests and also made sure worked by creating an integration test with the metrics collector.

Closes: #51

Signed-off-by: Julian Goh <juliangohsl@gmail.com>
