### PR TITLE
feat: Zookeeper metrics collecting

### DIFF
--- a/metrics-collector/src/test/java/io/julian/metrics/collector/server/handlers/AbstractHandlerTest.java
+++ b/metrics-collector/src/test/java/io/julian/metrics/collector/server/handlers/AbstractHandlerTest.java
@@ -26,11 +26,9 @@ public abstract class AbstractHandlerTest {
     }
 
     protected TestServerComponents startServer(final TestContext context) {
-        TestServerComponents server = new TestServerComponents();
         Configuration configuration = new Configuration();
         configuration.setReportPath(ReportCreatorTest.REPORT_LOCATION);
-        server.setUpServer(configuration, context, vertx);
-        return server;
+        return startServer(configuration, context);
     }
 
     protected TestServerComponents startServer(final Configuration configuration, final TestContext context) {

--- a/server/src/test/java/io/julian/server/api/client/ServerClientTest.java
+++ b/server/src/test/java/io/julian/server/api/client/ServerClientTest.java
@@ -23,8 +23,14 @@ public class ServerClientTest extends AbstractServerHandlerTest {
     public void TestServerClientSuccessfullySendCoordinateMessage(final TestContext context) {
         setUpApiServer(context);
         ServerClient client = new ServerClient(vertx, new Configuration());
+        Async async = context.async();
         client.sendCoordinateMessageToServer(OTHER_SERVER_CONFIGURATION, CoordinationMessage.fromJson(JSON))
-            .onComplete(context.asyncAssertSuccess(context::assertNull));
+            .onComplete(context.asyncAssertSuccess(res -> {
+                context.assertNull(res);
+                async.complete();
+            }));
+        async.awaitSuccess();
+        tearDownServer(context);
     }
 
     @Test
@@ -50,6 +56,7 @@ public class ServerClientTest extends AbstractServerHandlerTest {
                 async.complete();
             }));
         async.awaitSuccess();
+        tearDownServer(context);
     }
 
     @Test
@@ -70,6 +77,7 @@ public class ServerClientTest extends AbstractServerHandlerTest {
                 async.complete();
             }));
         async.awaitSuccess();
+        tearDownServer(context);
     }
 
     @Test

--- a/server/src/test/java/io/julian/server/endpoints/AbstractHandlerTest.java
+++ b/server/src/test/java/io/julian/server/endpoints/AbstractHandlerTest.java
@@ -92,28 +92,29 @@ public abstract class AbstractHandlerTest {
     protected Future<String> sendSuccessfulPOSTMessage(final TestContext context, final  WebClient client, final JsonObject message) {
         Promise<String> uuid = Promise.promise();
         sendPOSTMessage(context, client, createPostMessage(message))
-            .compose(res -> {
+            .onComplete(context.asyncAssertSuccess(res -> {
                 context.assertEquals(res.statusCode(), 200);
                 context.assertNotNull(res.bodyAsJsonObject().getString(MessageIDResponse.MESSAGE_ID_KEY));
                 uuid.complete(res.bodyAsJsonObject().getString(MessageIDResponse.MESSAGE_ID_KEY));
-                return Future.succeededFuture();
-            });
+            }));
         return uuid.future();
     }
 
     protected Future<Void> sendUnsuccessfulGETMessage(final TestContext context, final WebClient client,
                                                final String messageId, final Throwable error,
                                                final int expectedStatusCode) {
-        return sendGETMessage(context, client, messageId)
-            .compose(res -> {
+        Promise<Void> get = Promise.promise();
+        sendGETMessage(context, client, messageId)
+            .onComplete(context.asyncAssertSuccess(res -> {
                 context.assertEquals(res.statusCode(), expectedStatusCode);
                 if (error != null) {
                     context.assertEquals(res.bodyAsJsonObject(), new ErrorResponse(expectedStatusCode, error).toJson());
                 } else {
                     context.assertNull(res.bodyAsJsonObject());
                 }
-                return Future.succeededFuture();
-            });
+                get.complete();
+            }));
+        return get.future();
     }
 
     protected void sendUnsuccessfulPOSTMessage(final TestContext context, final WebClient client,
@@ -134,13 +135,12 @@ public abstract class AbstractHandlerTest {
     protected Future<String> sendSuccessfulDELETEMessage(final TestContext context, final WebClient client, final String messageId, final boolean expectMessage) {
         Promise<String> completed = Promise.promise();
         sendDELETEMessage(context, client, messageId)
-            .compose(res -> {
+            .onComplete(context.asyncAssertSuccess(res -> {
                 context.assertEquals(200, res.statusCode());
                 context.assertEquals(new MessageIDResponse(messageId).toJson().encodePrettily(), res.bodyAsJsonObject().encodePrettily());
                 context.assertEquals(expectMessage, server.getMessages().hasUUID(messageId));
                 completed.complete(messageId);
-                return Future.succeededFuture();
-            });
+            }));
         return completed.future();
     }
 

--- a/server/src/test/java/io/julian/server/endpoints/AbstractHandlerTest.java
+++ b/server/src/test/java/io/julian/server/endpoints/AbstractHandlerTest.java
@@ -65,6 +65,13 @@ public abstract class AbstractHandlerTest {
         async.awaitSuccess();
     }
 
+    protected void tearDownServer(final TestContext context) {
+        server = null;
+        Async async = context.async();
+        api.close(v -> async.complete());
+        async.awaitSuccess();
+    }
+
     protected JsonObject createPostMessage(final JsonObject message) {
         return new JsonObject()
             .put("message", message);
@@ -94,10 +101,10 @@ public abstract class AbstractHandlerTest {
         return uuid.future();
     }
 
-    protected void sendUnsuccessfulGETMessage(final TestContext context, final WebClient client,
+    protected Future<Void> sendUnsuccessfulGETMessage(final TestContext context, final WebClient client,
                                                final String messageId, final Throwable error,
                                                final int expectedStatusCode) {
-        sendGETMessage(context, client, messageId)
+        return sendGETMessage(context, client, messageId)
             .compose(res -> {
                 context.assertEquals(res.statusCode(), expectedStatusCode);
                 if (error != null) {
@@ -137,9 +144,9 @@ public abstract class AbstractHandlerTest {
         return completed.future();
     }
 
-    protected void sendUnsuccessfulDELETEMessage(final TestContext context, final WebClient client, final String messageId,
+    protected Future<Void> sendUnsuccessfulDELETEMessage(final TestContext context, final WebClient client, final String messageId,
                                                  final int expectedStatusCode, final Exception exception) {
-        sendDELETEMessage(context, client, messageId)
+        return sendDELETEMessage(context, client, messageId)
             .compose(res -> {
                 context.assertEquals(expectedStatusCode, res.statusCode());
                 context.assertEquals(new ErrorResponse(expectedStatusCode, exception).toJson().encodePrettily(),

--- a/server/src/test/java/io/julian/server/endpoints/client/DeleteMessageHandlerTest.java
+++ b/server/src/test/java/io/julian/server/endpoints/client/DeleteMessageHandlerTest.java
@@ -23,13 +23,11 @@ public class DeleteMessageHandlerTest extends AbstractServerHandlerTest {
         sendSuccessfulPOSTMessage(context, client, TEST_MESSAGE)
             .compose(id -> sendSuccessfulGETMessage(context, client, id, TEST_MESSAGE))
             .compose(id -> sendSuccessfulDELETEMessage(context, client, id, false))
-            .compose(id -> {
-                sendUnsuccessfulGETMessage(context, client, id,
-                    new Exception(String.format("Could not find entry for uuid '%s'", id)), 404);
-                async.complete();
-                return Future.succeededFuture();
-            });
+            .compose(id -> sendUnsuccessfulGETMessage(context, client, id,
+                new Exception(String.format("Could not find entry for uuid '%s'", id)), 404))
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
         async.awaitSuccess();
+        tearDownServer(context);
     }
 
     @Test
@@ -46,10 +44,11 @@ public class DeleteMessageHandlerTest extends AbstractServerHandlerTest {
             .compose(id -> sendSuccessfulDELETEMessage(context, client, id, true))
             .compose(id -> {
                 sendSuccessfulGETMessage(context, client, id, TEST_MESSAGE);
-                async.complete();
                 return Future.succeededFuture();
-            });
+            })
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
         async.awaitSuccess();
+        tearDownServer(context);
     }
 
     @Test
@@ -58,7 +57,11 @@ public class DeleteMessageHandlerTest extends AbstractServerHandlerTest {
         WebClient client = WebClient.create(this.vertx);
         String invalidID = "invalid-id";
         Exception error = new Exception(String.format(DeleteMessageHandler.ERROR_RESPONSE, invalidID));
-        sendUnsuccessfulDELETEMessage(context, client, invalidID, 404, error);
+        Async async = context.async();
+        sendUnsuccessfulDELETEMessage(context, client, invalidID, 404, error)
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+        async.awaitSuccess();
+        tearDownServer(context);
     }
 
     @Test
@@ -67,7 +70,11 @@ public class DeleteMessageHandlerTest extends AbstractServerHandlerTest {
         WebClient client = WebClient.create(this.vertx);
         server.getController().setStatus(ServerStatus.UNREACHABLE);
 
-        sendUnsuccessfulDELETEMessage(context, client, "invalid-id", 500, UNREACHABLE_ERROR);
+        Async async = context.async();
+        sendUnsuccessfulDELETEMessage(context, client, "invalid-id", 500, UNREACHABLE_ERROR)
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+        async.awaitSuccess();
+        tearDownServer(context);
     }
 
     @Test
@@ -76,8 +83,11 @@ public class DeleteMessageHandlerTest extends AbstractServerHandlerTest {
         WebClient client = WebClient.create(this.vertx);
         server.getController().setStatus(ServerStatus.PROBABILISTIC_FAILURE);
         server.getController().setFailureChance(1);
-        sendUnsuccessfulDELETEMessage(context, client, "invalid-id", 500, PROBABILISTIC_FAILURE_ERROR);
-
+        Async async = context.async();
+        sendUnsuccessfulDELETEMessage(context, client, "invalid-id", 500, PROBABILISTIC_FAILURE_ERROR)
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+        async.awaitSuccess();
+        tearDownServer(context);
     }
 
     @Test
@@ -87,8 +97,12 @@ public class DeleteMessageHandlerTest extends AbstractServerHandlerTest {
         server.getController().setStatus(ServerStatus.PROBABILISTIC_FAILURE);
         server.getController().setFailureChance(0);
 
+        Async async = context.async();
         sendSuccessfulPOSTMessage(context, client, TEST_MESSAGE)
-            .compose(id -> sendSuccessfulDELETEMessage(context, client, id, false));
+            .compose(id -> sendSuccessfulDELETEMessage(context, client, id, false))
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+        async.awaitSuccess();
+        tearDownServer(context);
     }
 
     @Test
@@ -96,6 +110,7 @@ public class DeleteMessageHandlerTest extends AbstractServerHandlerTest {
         setUpApiServer(context);
         WebClient client = WebClient.create(this.vertx);
 
+        Async async = context.async();
         client
             .delete(Configuration.DEFAULT_SERVER_PORT, Configuration.DEFAULT_SERVER_HOST, CLIENT_URI)
             .send(context.asyncAssertSuccess(res -> {
@@ -103,6 +118,9 @@ public class DeleteMessageHandlerTest extends AbstractServerHandlerTest {
                 context.assertEquals(new ErrorResponse(400,
                         new Exception("Error during validation of request. Parameter \"messageId\" inside query not found")).toJson().encodePrettily(),
                     res.bodyAsJsonObject().encodePrettily());
+                async.complete();
             }));
+        async.awaitSuccess();
+        tearDownServer(context);
     }
 }

--- a/server/src/test/java/io/julian/server/endpoints/client/DeleteMessageHandlerTest.java
+++ b/server/src/test/java/io/julian/server/endpoints/client/DeleteMessageHandlerTest.java
@@ -4,7 +4,6 @@ import io.julian.server.components.Configuration;
 import io.julian.server.endpoints.control.AbstractServerHandlerTest;
 import io.julian.server.models.ServerStatus;
 import io.julian.server.models.response.ErrorResponse;
-import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -42,10 +41,7 @@ public class DeleteMessageHandlerTest extends AbstractServerHandlerTest {
                 return sendSuccessfulGETMessage(context, client, id, TEST_MESSAGE);
             })
             .compose(id -> sendSuccessfulDELETEMessage(context, client, id, true))
-            .compose(id -> {
-                sendSuccessfulGETMessage(context, client, id, TEST_MESSAGE);
-                return Future.succeededFuture();
-            })
+            .compose(id -> sendSuccessfulGETMessage(context, client, id, TEST_MESSAGE))
             .onComplete(context.asyncAssertSuccess(v -> async.complete()));
         async.awaitSuccess();
         tearDownServer(context);

--- a/server/src/test/java/io/julian/server/endpoints/client/GetOverviewHandlerTest.java
+++ b/server/src/test/java/io/julian/server/endpoints/client/GetOverviewHandlerTest.java
@@ -20,5 +20,6 @@ public class GetOverviewHandlerTest extends AbstractServerHandlerTest {
         sendSuccessfulGETOverview(context, client, new ServerOverview(Configuration.DEFAULT_SERVER_HOST, Configuration.DEFAULT_SERVER_PORT, 0, new ArrayList<>()))
             .onComplete(v -> async.complete());
         async.awaitSuccess();
+        tearDownServer(context);
     }
 }

--- a/server/src/test/java/io/julian/server/endpoints/control/AbstractServerHandlerTest.java
+++ b/server/src/test/java/io/julian/server/endpoints/control/AbstractServerHandlerTest.java
@@ -16,7 +16,6 @@ import org.junit.Assert;
 public abstract class AbstractServerHandlerTest extends AbstractHandlerTest {
     protected final static String SET_SETTINGS_ENDPOINT = "/server";
 
-
     protected Future<Object> POSTSuccessfulServerSettings(final TestContext context, final WebClient client, final ServerSettings settings,
                                        final ServerStatus expectedStatus, final float expectedFailureChance) {
         return POSTServerSettings(context, client, settings.toJson())
@@ -45,26 +44,28 @@ public abstract class AbstractServerHandlerTest extends AbstractHandlerTest {
         return postRes.future();
     }
 
-    protected Future<Object> GETAndAssertServerSettings(final TestContext context, final WebClient client,
+    protected Future<Void> GETAndAssertServerSettings(final TestContext context, final WebClient client,
                                             final ServerStatus expectedStatus, final float expectedFailureChance) {
-        return GETServerSettings(context, client)
-            .compose(res -> {
+        Promise<Void> get = Promise.promise();
+        GETServerSettings(context, client)
+            .onComplete(context.asyncAssertSuccess(res -> {
                 ServerSettings receivedSettings = res.bodyAsJsonObject().mapTo(ServerSettings.class);
                 Assert.assertEquals(expectedFailureChance, receivedSettings.getFailureChance(), 0);
                 Assert.assertEquals(expectedStatus, receivedSettings.getStatus());
                 Assert.assertEquals(expectedFailureChance, server.getController().getFailureChance(), 0);
                 Assert.assertEquals(expectedStatus, server.getController().getStatus());
-                return Future.succeededFuture();
-            });
+                get.complete();
+            }));
+        return get.future();
     }
 
     private Future<HttpResponse<Buffer>> GETServerSettings(final TestContext context, final WebClient client) {
-        Promise<HttpResponse<Buffer>> postRes = Promise.promise();
+        Promise<HttpResponse<Buffer>> get = Promise.promise();
 
         client
-            .post(Configuration.DEFAULT_SERVER_PORT, Configuration.DEFAULT_SERVER_HOST, SET_SETTINGS_ENDPOINT)
-            .send(context.asyncAssertSuccess(postRes::complete));
+            .get(Configuration.DEFAULT_SERVER_PORT, Configuration.DEFAULT_SERVER_HOST, SET_SETTINGS_ENDPOINT)
+            .send(context.asyncAssertSuccess(get::complete));
 
-        return postRes.future();
+        return get.future();
     }
 }

--- a/server/src/test/java/io/julian/server/endpoints/control/GetServerSettingsHandlerTest.java
+++ b/server/src/test/java/io/julian/server/endpoints/control/GetServerSettingsHandlerTest.java
@@ -14,6 +14,7 @@ public class GetServerSettingsHandlerTest extends AbstractServerHandlerTest {
         WebClient client = WebClient.create(this.vertx);
 
         GETAndAssertServerSettings(context, client, Controller.DEFAULT_SERVER_STATUS, Controller.DEFAULT_MESSAGE_FAILURE_CHANCE);
+        tearDownServer(context);
     }
 
     @Test
@@ -28,5 +29,6 @@ public class GetServerSettingsHandlerTest extends AbstractServerHandlerTest {
         GETAndAssertServerSettings(context, client, Controller.DEFAULT_SERVER_STATUS, Controller.DEFAULT_MESSAGE_FAILURE_CHANCE)
             .compose(v -> POSTSuccessfulServerSettings(context, client, settings, expectedStatus, failureChance))
             .compose(v -> GETAndAssertServerSettings(context, client, expectedStatus, failureChance));
+        tearDownServer(context);
     }
 }

--- a/server/src/test/java/io/julian/server/endpoints/control/GetServerSettingsHandlerTest.java
+++ b/server/src/test/java/io/julian/server/endpoints/control/GetServerSettingsHandlerTest.java
@@ -3,6 +3,7 @@ package io.julian.server.endpoints.control;
 import io.julian.server.components.Controller;
 import io.julian.server.models.ServerStatus;
 import io.julian.server.models.control.ServerSettings;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.web.client.WebClient;
 import org.junit.Test;
@@ -13,7 +14,10 @@ public class GetServerSettingsHandlerTest extends AbstractServerHandlerTest {
         setUpApiServer(context);
         WebClient client = WebClient.create(this.vertx);
 
-        GETAndAssertServerSettings(context, client, Controller.DEFAULT_SERVER_STATUS, Controller.DEFAULT_MESSAGE_FAILURE_CHANCE);
+        Async async = context.async();
+        GETAndAssertServerSettings(context, client, Controller.DEFAULT_SERVER_STATUS, Controller.DEFAULT_MESSAGE_FAILURE_CHANCE)
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+        async.awaitSuccess();
         tearDownServer(context);
     }
 
@@ -26,9 +30,13 @@ public class GetServerSettingsHandlerTest extends AbstractServerHandlerTest {
 
         ServerSettings settings = new ServerSettings(expectedStatus, failureChance);
 
+        Async async = context.async();
         GETAndAssertServerSettings(context, client, Controller.DEFAULT_SERVER_STATUS, Controller.DEFAULT_MESSAGE_FAILURE_CHANCE)
             .compose(v -> POSTSuccessfulServerSettings(context, client, settings, expectedStatus, failureChance))
-            .compose(v -> GETAndAssertServerSettings(context, client, expectedStatus, failureChance));
+            .compose(v -> GETAndAssertServerSettings(context, client, expectedStatus, failureChance))
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+
+        async.awaitSuccess();
         tearDownServer(context);
     }
 }

--- a/server/src/test/java/io/julian/server/endpoints/control/SetServerSettingsHandlerTest.java
+++ b/server/src/test/java/io/julian/server/endpoints/control/SetServerSettingsHandlerTest.java
@@ -3,6 +3,7 @@ package io.julian.server.endpoints.control;
 import io.julian.server.components.Controller;
 import io.julian.server.models.ServerStatus;
 import io.julian.server.models.control.ServerSettings;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.web.client.WebClient;
 import org.junit.Test;
@@ -15,7 +16,11 @@ public class SetServerSettingsHandlerTest extends AbstractServerHandlerTest {
         setUpApiServer(context);
 
         WebClient client = WebClient.create(this.vertx);
-        POSTSuccessfulServerSettings(context, client, new ServerSettings(expectedStatus, failureChance), expectedStatus, failureChance);
+        Async async = context.async();
+        POSTSuccessfulServerSettings(context, client, new ServerSettings(expectedStatus, failureChance), expectedStatus, failureChance)
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+        async.awaitSuccess();
+        tearDownServer(context);
     }
 
     @Test
@@ -24,8 +29,12 @@ public class SetServerSettingsHandlerTest extends AbstractServerHandlerTest {
         setUpApiServer(context);
 
         WebClient client = WebClient.create(this.vertx);
+        Async async = context.async();
         POSTSuccessfulServerSettings(context, client, new ServerSettings(expectedStatus, null), expectedStatus,
-            Controller.DEFAULT_MESSAGE_FAILURE_CHANCE);
+            Controller.DEFAULT_MESSAGE_FAILURE_CHANCE)
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+        async.awaitSuccess();
+        tearDownServer(context);
     }
 
     @Test
@@ -36,7 +45,11 @@ public class SetServerSettingsHandlerTest extends AbstractServerHandlerTest {
         setUpApiServer(context);
 
         WebClient client = WebClient.create(this.vertx);
+        Async async = context.async();
         POSTSuccessfulServerSettings(context, client, new ServerSettings(status, expectedFailureChance), ServerStatus.AVAILABLE,
-            expectedFailureChance);
+            expectedFailureChance)
+            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+        async.awaitSuccess();
+        tearDownServer(context);
     }
 }

--- a/zookeeper/src/main/java/io/julian/zookeeper/AbstractHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/AbstractHandler.java
@@ -1,0 +1,28 @@
+package io.julian.zookeeper;
+
+import io.julian.metrics.collector.models.TrackedMessage;
+import io.julian.server.api.client.ServerClient;
+import io.julian.server.models.coordination.CoordinationMessage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public abstract class AbstractHandler {
+    private final static Logger log = LogManager.getLogger(AbstractHandler.class);
+    protected final ServerClient client;
+
+    public AbstractHandler(final ServerClient client) {
+        this.client = client;
+    }
+
+    public void sendToMetricsCollector(final int statusCode, final CoordinationMessage message) {
+        log.traceEntry(() -> statusCode, () -> message);
+        log.info(String.format("Attempting to send to metrics '%s' collector", message.getMetadata().getMessageID()));
+        client.trackMessage(new TrackedMessage(statusCode, message.getMetadata().getMessageID(), message.toJson().toBuffer().getBytes().length))
+            .onSuccess(v -> log.info(String.format("Successfully sent '%s' to metrics collector", message.getMetadata().getMessageID())))
+            .onFailure(cause -> {
+                log.info(String.format("Failed to send '%s' to metrics collector", message.getMetadata().getMessageID()));
+                log.error(cause.getMessage());
+            });
+        log.traceExit();
+    }
+}

--- a/zookeeper/src/main/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandler.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 @Getter
 public class FollowerDiscoveryHandler {
+    public final static String FOLLOWER_DISCOVERY_MESSAGE_ID = "followerDiscoveryID";
     private final static Logger log = LogManager.getLogger(FollowerDiscoveryHandler.class);
     private final State state;
     private final CandidateInformationRegistry registry;
@@ -59,7 +60,7 @@ public class FollowerDiscoveryHandler {
     public CoordinationMessage createCoordinationMessage() {
         log.traceEntry();
         return log.traceExit(new CoordinationMessage(
-            new CoordinationMetadata(HTTPRequest.UNKNOWN, "", DiscoveryHandler.DISCOVERY_TYPE),
+            new CoordinationMetadata(HTTPRequest.UNKNOWN, FOLLOWER_DISCOVERY_MESSAGE_ID, DiscoveryHandler.DISCOVERY_TYPE),
             null,
             state.toJson()));
     }

--- a/zookeeper/src/main/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandler.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 
 public class LeaderDiscoveryHandler {
     public final static String LEADER_STATE_UPDATE_TYPE = "leader_state_update";
+    public final static String LEADER_STATE_UPDATE_MESSAGE_ID = "leaderStateUpdate";
+    public final static String LEADER_STATE_BROADCAST_MESSAGE_ID = "leaderStateBroadcast";
     private final static Logger log = LogManager.getLogger(LeadershipElectionHandler.class);
 
     private final AtomicReference<State> latestState;
@@ -125,19 +127,14 @@ public class LeaderDiscoveryHandler {
 
     public CoordinationMessage createBroadcastMessage(final String type) {
         log.traceEntry(() -> type);
-        return log.traceExit(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN, "", type), null, null));
+        return log.traceExit(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN, LEADER_STATE_BROADCAST_MESSAGE_ID, type), null, null));
     }
 
     public CoordinationMessage createStateUpdate() {
         log.traceEntry();
         return log.traceExit(new CoordinationMessage(
-            new CoordinationMetadata(HTTPRequest.UNKNOWN, "", LEADER_STATE_UPDATE_TYPE),
+            new CoordinationMetadata(HTTPRequest.UNKNOWN, LEADER_STATE_UPDATE_MESSAGE_ID, LEADER_STATE_UPDATE_TYPE),
             null,
             new Zxid(state.getLeaderEpoch(), state.getCounter()).toJson()));
-    }
-
-    public ConcurrentLinkedQueue<CoordinationMessage> getDeadCoordinationMessages() {
-        log.traceEntry();
-        return log.traceExit(deadCoordinationMessages);
     }
 }

--- a/zookeeper/src/main/java/io/julian/zookeeper/election/LeadershipElectionHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/election/LeadershipElectionHandler.java
@@ -25,6 +25,7 @@ public class LeadershipElectionHandler {
     public final static String LEADER_LABEL = "leader";
     public final static String FOLLOWER_LABEL = "follower";
     public final static String TYPE = "candidate_information";
+    public final static String MESSAGE_ID = "electionBroadcast";
 
     private final long candidateNumber;
     private final CandidateInformationRegistry candidateRegistry;
@@ -89,7 +90,7 @@ public class LeadershipElectionHandler {
      */
     public CoordinationMessage createCandidateInformationMessage(final long candidateNumber, final ServerConfiguration serverConfig) {
         log.traceEntry(() -> candidateNumber, () -> serverConfig);
-        return log.traceExit(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN, null, TYPE),
+        return log.traceExit(new CoordinationMessage(new CoordinationMetadata(HTTPRequest.UNKNOWN, MESSAGE_ID, TYPE),
             null,
             new CandidateInformation(serverConfig.getHost(), serverConfig.getPort(), candidateNumber).toJson()));
     }

--- a/zookeeper/src/main/java/io/julian/zookeeper/synchronize/FollowerSynchronizeHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/synchronize/FollowerSynchronizeHandler.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class FollowerSynchronizeHandler {
+    public static final String MESSAGE_ID = "followerSynchronizeMessage";
+
     private static final Logger log = LogManager.getLogger(FollowerSynchronizeHandler.class);
     private final Vertx vertx;
     private final State state;
@@ -108,7 +110,7 @@ public class FollowerSynchronizeHandler {
     public CoordinationMessage getCoordinationMessage() {
         log.traceEntry();
         return log.traceExit(new CoordinationMessage(
-            new CoordinationMetadata(HTTPRequest.UNKNOWN, null, SynchronizeHandler.SYNCHRONIZE_TYPE),
+            new CoordinationMetadata(HTTPRequest.UNKNOWN, MESSAGE_ID, SynchronizeHandler.SYNCHRONIZE_TYPE),
             null,
             null));
     }

--- a/zookeeper/src/main/java/io/julian/zookeeper/synchronize/LeaderSynchronizeHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/synchronize/LeaderSynchronizeHandler.java
@@ -19,7 +19,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 public class LeaderSynchronizeHandler {
-    private static final Logger log = LogManager.getLogger(LeaderDiscoveryHandler.class);
+    public final static String MESSAGE_ID = "leaderSynchronize";
+    private final static Logger log = LogManager.getLogger(LeaderDiscoveryHandler.class);
 
     private final State state;
     private final RegistryManager manager;
@@ -75,7 +76,7 @@ public class LeaderSynchronizeHandler {
     public CoordinationMessage getCoordinationMessage() {
         log.traceEntry();
         return log.traceExit(new CoordinationMessage(
-            new CoordinationMetadata(HTTPRequest.UNKNOWN, null, SynchronizeHandler.SYNCHRONIZE_TYPE),
+            new CoordinationMetadata(HTTPRequest.UNKNOWN, MESSAGE_ID, SynchronizeHandler.SYNCHRONIZE_TYPE),
             null,
             state.toJson()));
     }

--- a/zookeeper/src/main/java/io/julian/zookeeper/synchronize/LeaderSynchronizeHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/synchronize/LeaderSynchronizeHandler.java
@@ -5,6 +5,7 @@ import io.julian.server.api.client.ServerClient;
 import io.julian.server.models.HTTPRequest;
 import io.julian.server.models.coordination.CoordinationMessage;
 import io.julian.server.models.coordination.CoordinationMetadata;
+import io.julian.zookeeper.AbstractHandler;
 import io.julian.zookeeper.controller.State;
 import io.julian.zookeeper.discovery.LeaderDiscoveryHandler;
 import io.vertx.core.CompositeFuture;
@@ -18,20 +19,19 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-public class LeaderSynchronizeHandler {
+public class LeaderSynchronizeHandler extends AbstractHandler {
     public final static String MESSAGE_ID = "leaderSynchronize";
     private final static Logger log = LogManager.getLogger(LeaderDiscoveryHandler.class);
 
     private final State state;
     private final RegistryManager manager;
-    private final ServerClient client;
     private final AtomicInteger acknowledgements = new AtomicInteger();
     private final ConcurrentLinkedQueue<CoordinationMessage> deadCoordinationMessages;
 
     public LeaderSynchronizeHandler(final State state, final RegistryManager manager, final ServerClient client, final ConcurrentLinkedQueue<CoordinationMessage> deadCoordinationMessages) {
+        super(client);
         this.state = state;
         this.manager = manager;
-        this.client = client;
         this.deadCoordinationMessages = deadCoordinationMessages;
     }
 
@@ -39,22 +39,25 @@ public class LeaderSynchronizeHandler {
         log.traceEntry();
         log.info("Leader broadcasting state to followers");
         Promise<Void> res = Promise.promise();
+        final CoordinationMessage message = getCoordinationMessage();
         List<Future> broadcast = manager
             .getOtherServers()
             .stream()
-            .map(server -> client.sendCoordinateMessageToServer(server, getCoordinationMessage()))
+            .map(server -> client.sendCoordinateMessageToServer(server, message))
             .collect(Collectors.toList());
 
         CompositeFuture.all(broadcast)
             .onSuccess(v -> {
                 log.info("Leader successfully broadcast state to followers");
                 acknowledgements.set(0);
+                sendToMetricsCollector(200, message);
                 res.complete();
             })
             .onFailure(cause -> {
                 log.info("Leader unsuccessfully broadcast state to followers");
                 deadCoordinationMessages.add(getCoordinationMessage());
                 log.error(cause);
+                sendToMetricsCollector(400, message);
                 res.fail(cause);
             });
 

--- a/zookeeper/src/main/java/io/julian/zookeeper/write/FollowerWriteHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/write/FollowerWriteHandler.java
@@ -85,7 +85,7 @@ public class FollowerWriteHandler {
     public CoordinationMessage createCoordinationMessage(final MessagePhase phase, final Zxid id) {
         log.traceEntry(() -> phase, () -> id);
         return log.traceExit(new CoordinationMessage(
-            new CoordinationMetadata(HTTPRequest.UNKNOWN, null, ACK_TYPE),
+            new CoordinationMetadata(HTTPRequest.UNKNOWN, String.format("%s-%s", phase, id.toString()), ACK_TYPE),
             null,
             new ShortenedExchange(phase, id).toJson()
         ));

--- a/zookeeper/src/main/java/io/julian/zookeeper/write/FollowerWriteHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/write/FollowerWriteHandler.java
@@ -5,6 +5,7 @@ import io.julian.server.models.HTTPRequest;
 import io.julian.server.models.control.ClientMessage;
 import io.julian.server.models.coordination.CoordinationMessage;
 import io.julian.server.models.coordination.CoordinationMetadata;
+import io.julian.zookeeper.AbstractHandler;
 import io.julian.zookeeper.election.CandidateInformationRegistry;
 import io.julian.zookeeper.models.MessagePhase;
 import io.julian.zookeeper.models.ShortenedExchange;
@@ -16,18 +17,17 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-public class FollowerWriteHandler {
+public class FollowerWriteHandler extends AbstractHandler  {
     private final static Logger log = LogManager.getLogger(FollowerWriteHandler.class);
     private final CandidateInformationRegistry registry;
-    private final ServerClient client;
     private final ConcurrentLinkedQueue<CoordinationMessage> deadCoordinationMessages;
 
     public final static String ACK_TYPE = "state_acknowledgement";
     public final static String FORWARD_TYPE = "forward";
 
     public FollowerWriteHandler(final CandidateInformationRegistry registry, final ServerClient client, final ConcurrentLinkedQueue<CoordinationMessage> deadCoordinationMessages) {
+        super(client);
         this.registry = registry;
-        this.client = client;
         this.deadCoordinationMessages = deadCoordinationMessages;
     }
 
@@ -40,11 +40,13 @@ public class FollowerWriteHandler {
             .sendCoordinateMessageToServer(registry.getLeaderServerConfiguration(), reply)
             .onSuccess(res -> {
                 log.info(String.format("Successfully forwarded %s to leader", message.getRequest()));
+                sendToMetricsCollector(200, reply);
                 forward.complete();
             })
             .onFailure(cause -> {
                 log.info(String.format("Failed to forwarded %s to leader", message.getRequest()));
                 deadCoordinationMessages.add(reply);
+                sendToMetricsCollector(400, reply);
                 log.error(cause.getMessage());
                 forward.fail(cause);
             });
@@ -70,10 +72,12 @@ public class FollowerWriteHandler {
         client.sendCoordinateMessageToServer(registry.getLeaderServerConfiguration(), message)
             .onSuccess(res -> {
                 log.info(String.format("Successfully sent '%s' reply for Zxid %s to leader", phase.toValue(), id.toString()));
+                sendToMetricsCollector(200, message);
                 reply.complete();
             })
             .onFailure(cause -> {
                 log.info(String.format("Could not send '%s' reply for Zxid %s to leader", phase.toValue(), id.toString()));
+                sendToMetricsCollector(400, message);
                 deadCoordinationMessages.add(message);
                 log.error(cause);
                 reply.fail(cause);

--- a/zookeeper/src/main/java/io/julian/zookeeper/write/FollowerWriteHandler.java
+++ b/zookeeper/src/main/java/io/julian/zookeeper/write/FollowerWriteHandler.java
@@ -77,9 +77,9 @@ public class FollowerWriteHandler extends AbstractHandler  {
             })
             .onFailure(cause -> {
                 log.info(String.format("Could not send '%s' reply for Zxid %s to leader", phase.toValue(), id.toString()));
+                log.error(cause);
                 sendToMetricsCollector(400, message);
                 deadCoordinationMessages.add(message);
-                log.error(cause);
                 reply.fail(cause);
             });
 

--- a/zookeeper/src/test/java/io/julian/TestMetricsCollector.java
+++ b/zookeeper/src/test/java/io/julian/TestMetricsCollector.java
@@ -1,0 +1,47 @@
+package io.julian;
+
+import io.julian.metrics.collector.server.Configuration;
+import io.julian.metrics.collector.server.Server;
+import io.julian.server.models.control.ServerConfiguration;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Assert;
+
+import java.io.File;
+
+public class TestMetricsCollector {
+    public Server server;
+    public HttpServer api;
+
+    public static final String OPENAPI_SPEC_LOCATION = System.getProperty("user.dir") + File.separator + "../metrics-collector" + File.separator + Configuration.DEFAULT_OPENAPI_SPEC_LOCATION;
+
+    public void setUpMetricsCollector(final ServerConfiguration configuration, final TestContext context, final Vertx vertx) {
+        server = new Server(new Configuration());
+        Async async = context.async();
+        api = vertx.createHttpServer(new HttpServerOptions()
+            .setPort(configuration.getPort())
+            .setHost(configuration.getHost()));
+
+        server.startServer(vertx, OPENAPI_SPEC_LOCATION)
+            .onComplete(context.asyncAssertSuccess(compositeFuture -> api.requestHandler(server.getRouterFactory().getRouter()).listen(ar -> {
+                context.assertTrue(ar.succeeded());
+                async.complete();
+            })));
+
+        async.awaitSuccess();
+    }
+
+    public void tearDownMetricsCollector(final TestContext context) {
+        server = null;
+        Async async = context.async();
+        api.close(context.asyncAssertSuccess(v ->  async.complete()));
+        async.awaitSuccess();
+    }
+
+    public void testHasExpectedStatusSize(final int expectedSize) {
+        Assert.assertEquals(expectedSize, server.getTracker().getStatuses().size());
+    }
+}

--- a/zookeeper/src/test/java/io/julian/zookeeper/AbstractServerBase.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/AbstractServerBase.java
@@ -1,5 +1,6 @@
 package io.julian.zookeeper;
 
+import io.julian.TestMetricsCollector;
 import io.julian.server.api.client.RegistryManager;
 import io.julian.server.api.client.ServerClient;
 import io.julian.server.components.Configuration;
@@ -19,6 +20,8 @@ public abstract class AbstractServerBase {
 
     public static final ServerConfiguration DEFAULT_SEVER_CONFIG = new ServerConfiguration(Configuration.DEFAULT_SERVER_HOST, Configuration.DEFAULT_SERVER_PORT);
     public static final ServerConfiguration SECOND_SERVER_CONFIG = new ServerConfiguration(Configuration.DEFAULT_SERVER_HOST, 9998);
+    public static final ServerConfiguration METRICS_COLLECTOR_CONFIG = new ServerConfiguration(Configuration.DEFAULT_METRICS_COLLECTOR_HOST, Configuration.DEFAULT_METRICS_COLLECTOR_PORT);
+
     public static final String CONNECTION_REFUSED_EXCEPTION = String.format("Connection refused: %s/127.0.0.1:%d", Configuration.DEFAULT_SERVER_HOST, Configuration.DEFAULT_SERVER_PORT);
 
     @Before
@@ -68,5 +71,11 @@ public abstract class AbstractServerBase {
 
     protected TestClient createTestClient() {
         return new TestClient(this.vertx);
+    }
+
+    protected TestMetricsCollector setUpMetricsCollector(final TestContext context) {
+        TestMetricsCollector metricsCollector = new TestMetricsCollector();
+        metricsCollector.setUpMetricsCollector(METRICS_COLLECTOR_CONFIG, context, vertx);
+        return metricsCollector;
     }
 }

--- a/zookeeper/src/test/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandlerTest.java
@@ -22,6 +22,7 @@ public class FollowerDiscoveryHandlerTest extends AbstractServerBase {
         FollowerDiscoveryHandler handler = getTestHandler(registry);
         CoordinationMessage message = handler.createCoordinationMessage();
         Assert.assertEquals(HTTPRequest.UNKNOWN, message.getMetadata().getRequest());
+        Assert.assertEquals(FollowerDiscoveryHandler.FOLLOWER_DISCOVERY_MESSAGE_ID, message.getMetadata().getMessageID());
         Assert.assertEquals(DiscoveryHandler.DISCOVERY_TYPE, message.getMetadata().getType());
         Assert.assertNull(message.getMessage());
         Assert.assertEquals(new State(vertx, new MessageStore()).toJson().encodePrettily(), message.getDefinition().encodePrettily());

--- a/zookeeper/src/test/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/discovery/FollowerDiscoveryHandlerTest.java
@@ -1,5 +1,6 @@
 package io.julian.zookeeper.discovery;
 
+import io.julian.TestMetricsCollector;
 import io.julian.server.components.MessageStore;
 import io.julian.server.models.HTTPRequest;
 import io.julian.server.models.coordination.CoordinationMessage;
@@ -31,19 +32,22 @@ public class FollowerDiscoveryHandlerTest extends AbstractServerBase {
     @Test
     public void TestReplyToLeaderIsSuccessful(final TestContext context) {
         TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        TestMetricsCollector metricsCollector = setUpMetricsCollector(context);
         CandidateInformationRegistry registry = createTestCandidateInformationRegistry(true);
         FollowerDiscoveryHandler handler = getTestHandler(registry);
 
         Async async = context.async();
         handler.replyToLeader()
-            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+            .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(1000, v1 -> async.complete())));
         async.awaitSuccess();
         tearDownServer(context, server);
+        metricsCollector.tearDownMetricsCollector(context);
     }
 
     @Test
     public void TestReplyToLeaderFails(final TestContext context) {
         CandidateInformationRegistry registry = createTestCandidateInformationRegistry(true);
+        TestMetricsCollector metricsCollector = setUpMetricsCollector(context);
         FollowerDiscoveryHandler handler = getTestHandler(registry);
 
         Async async = context.async();
@@ -51,9 +55,13 @@ public class FollowerDiscoveryHandlerTest extends AbstractServerBase {
             .onComplete(context.asyncAssertFailure(cause -> {
                 context.assertEquals(CONNECTION_REFUSED_EXCEPTION, cause.getMessage());
                 Assert.assertEquals(1, handler.getDeadCoordinationMessages().size());
-                async.complete();
+                vertx.setTimer(1000, v1 -> {
+                    metricsCollector.testHasExpectedStatusSize(1);
+                    async.complete();
+                });
             }));
         async.awaitSuccess();
+        metricsCollector.tearDownMetricsCollector(context);
     }
 
     @Test

--- a/zookeeper/src/test/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/discovery/LeaderDiscoveryHandlerTest.java
@@ -1,5 +1,6 @@
 package io.julian.zookeeper.discovery;
 
+import io.julian.TestMetricsCollector;
 import io.julian.server.components.MessageStore;
 import io.julian.server.models.HTTPRequest;
 import io.julian.server.models.coordination.CoordinationMessage;
@@ -86,12 +87,15 @@ public class LeaderDiscoveryHandlerTest extends AbstractServerBase {
     @Test
     public void TestBroadcastGatherZXIDSucceeds(final TestContext context) {
         TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        TestMetricsCollector collector = setUpMetricsCollector(context);
         LeaderDiscoveryHandler handler = createHandler();
         Async async = context.async();
         handler.broadcastGatherZXID()
-            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+            .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(500, v1 -> async.complete())));
         async.awaitSuccess();
+        collector.testHasExpectedStatusSize(1);
         tearDownServer(context, server);
+        collector.tearDownMetricsCollector(context);
     }
 
     @Test
@@ -111,12 +115,15 @@ public class LeaderDiscoveryHandlerTest extends AbstractServerBase {
     @Test
     public void TestBroadcastStateUpdateSucceeds(final TestContext context) {
         TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        TestMetricsCollector collector = setUpMetricsCollector(context);
         LeaderDiscoveryHandler handler = createHandler();
         Async async = context.async();
         handler.broadcastLeaderState()
-            .onComplete(context.asyncAssertSuccess(v -> async.complete()));
+            .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(500, v1 -> async.complete())));
         async.awaitSuccess();
         tearDownServer(context, server);
+        collector.testHasExpectedStatusSize(1);
+        collector.tearDownMetricsCollector(context);
     }
 
     @Test

--- a/zookeeper/src/test/java/io/julian/zookeeper/election/LeadershipElectionHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/election/LeadershipElectionHandlerTest.java
@@ -1,5 +1,6 @@
 package io.julian.zookeeper.election;
 
+import io.julian.TestMetricsCollector;
 import io.julian.server.api.client.RegistryManager;
 import io.julian.server.components.Configuration;
 import io.julian.server.components.Controller;
@@ -71,13 +72,15 @@ public class LeadershipElectionHandlerTest extends AbstractServerBase {
     @Test
     public void TestBroadcastIsSuccessful(final TestContext context) {
         TestServerComponents serverComponents = setUpBasicApiServer(context, AbstractServerBase.DEFAULT_SEVER_CONFIG);
-
+        TestMetricsCollector collector = setUpMetricsCollector(context);
         LeadershipElectionHandler handler = createTestHandler();
         Async async = context.async();
         handler.broadcast()
-            .onComplete(context.asyncAssertSuccess(res -> async.complete()));
+            .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(500, v1 -> async.complete())));
         async.awaitSuccess();
+        collector.testHasExpectedStatusSize(1);
         tearDownServer(context, serverComponents);
+        collector.tearDownMetricsCollector(context);
     }
 
     @Test

--- a/zookeeper/src/test/java/io/julian/zookeeper/election/LeadershipElectionHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/election/LeadershipElectionHandlerTest.java
@@ -100,6 +100,7 @@ public class LeadershipElectionHandlerTest extends AbstractServerBase {
         Assert.assertNull(message.getMessage());
         Assert.assertEquals(HTTPRequest.UNKNOWN, message.getMetadata().getRequest());
         Assert.assertEquals("candidate_information", message.getMetadata().getType());
+        Assert.assertEquals(LeadershipElectionHandler.MESSAGE_ID, message.getMetadata().getMessageID());
         Assert.assertEquals(DEFAULT_SEVER_CONFIG.getHost(), message.getDefinition().getString("host"));
         Assert.assertEquals(DEFAULT_SEVER_CONFIG.getPort(), message.getDefinition().getInteger("port").intValue());
         Assert.assertEquals(1L, message.getDefinition().getLong("candidate_number").longValue());

--- a/zookeeper/src/test/java/io/julian/zookeeper/synchronize/LeaderSynchronizeHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/synchronize/LeaderSynchronizeHandlerTest.java
@@ -1,5 +1,6 @@
 package io.julian.zookeeper.synchronize;
 
+import io.julian.TestMetricsCollector;
 import io.julian.server.api.client.RegistryManager;
 import io.julian.server.components.MessageStore;
 import io.julian.server.models.HTTPRequest;
@@ -31,15 +32,18 @@ public class LeaderSynchronizeHandlerTest extends AbstractServerBase {
     @Test
     public void TestBroadcastStateIsSuccessful(final TestContext context) {
         TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        TestMetricsCollector collector = setUpMetricsCollector(context);
         LeaderSynchronizeHandler handler = createTestHandler();
         Async async = context.async();
         handler.broadcastState()
-            .onComplete(context.asyncAssertSuccess(v -> {
+            .onComplete(context.asyncAssertSuccess(v1 -> vertx.setTimer(500, v2 -> {
                 Assert.assertEquals(0, handler.getAcknowledgements());
-                async.complete();
-            }));
+                vertx.setTimer(500, v -> async.complete());
+            })));
         async.awaitSuccess();
+        collector.testHasExpectedStatusSize(1);
         tearDownServer(context, server);
+        collector.tearDownMetricsCollector(context);
     }
 
     @Test

--- a/zookeeper/src/test/java/io/julian/zookeeper/synchronize/LeaderSynchronizeHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/synchronize/LeaderSynchronizeHandlerTest.java
@@ -20,6 +20,7 @@ public class LeaderSynchronizeHandlerTest extends AbstractServerBase {
         LeaderSynchronizeHandler handler = createTestHandler();
         CoordinationMessage message = handler.getCoordinationMessage();
         Assert.assertEquals(HTTPRequest.UNKNOWN, message.getMetadata().getRequest());
+        Assert.assertEquals(LeaderSynchronizeHandler.MESSAGE_ID, message.getMetadata().getMessageID());
         Assert.assertEquals(SynchronizeHandler.SYNCHRONIZE_TYPE, message.getMetadata().getType());
 
         Assert.assertEquals(SynchronizeHandler.SYNCHRONIZE_TYPE, message.getMetadata().getType());

--- a/zookeeper/src/test/java/io/julian/zookeeper/write/FollowerWriterHandlerTest.java
+++ b/zookeeper/src/test/java/io/julian/zookeeper/write/FollowerWriterHandlerTest.java
@@ -105,6 +105,7 @@ public class FollowerWriterHandlerTest extends AbstractServerBase {
         CoordinationMessage message = writeHandler.createCoordinationMessage(MessagePhase.ACK, ID);
         Assert.assertEquals(HTTPRequest.UNKNOWN, message.getMetadata().getRequest());
         Assert.assertEquals(FollowerWriteHandler.ACK_TYPE, message.getMetadata().getType());
+        Assert.assertEquals("ACK-" + ID.toString(), message.getMetadata().getMessageID());
         Assert.assertEquals(MessagePhase.ACK.toValue(), message.getDefinition().getString(ShortenedExchange.PHASE_KEY));
         Assert.assertEquals(COUNTER, message.getDefinition()
             .getJsonObject(ShortenedExchange.TRANSACTIONAL_ID_KEY).getInteger(Zxid.COUNTER_KEY).intValue());
@@ -114,6 +115,7 @@ public class FollowerWriterHandlerTest extends AbstractServerBase {
         message = writeHandler.createCoordinationMessage(MessagePhase.COMMIT, ID);
         Assert.assertEquals(HTTPRequest.UNKNOWN, message.getMetadata().getRequest());
         Assert.assertEquals(FollowerWriteHandler.ACK_TYPE, message.getMetadata().getType());
+        Assert.assertEquals("COMMIT-" + ID.toString(), message.getMetadata().getMessageID());
         Assert.assertEquals(MessagePhase.COMMIT.toValue(), message.getDefinition().getString(ShortenedExchange.PHASE_KEY));
         Assert.assertEquals(COUNTER, message.getDefinition()
             .getJsonObject(ShortenedExchange.TRANSACTIONAL_ID_KEY).getInteger(Zxid.COUNTER_KEY).intValue());


### PR DESCRIPTION
Zookeeper will now communicate with the metrics collector to update it on the progress of the server. If it fails to contact metrics collector, then it won't care as it is simply firing and forgetting. Also made some updates to the server tests to make them perform waits to get rid of the intermittent errors.

Closes: #53 

Signed-off-by: Julian Goh <juliangohsl@gmail.com>
