### PR TITLE
feat: Delete

### DIFF
--- a/gossip/src/main/java/io/julian/gossip/AbstractHandler.java
+++ b/gossip/src/main/java/io/julian/gossip/AbstractHandler.java
@@ -1,20 +1,42 @@
 package io.julian.gossip;
 
+import io.julian.gossip.components.GossipConfiguration;
 import io.julian.gossip.components.State;
 import io.julian.metrics.collector.models.TrackedMessage;
+import io.julian.server.api.client.RegistryManager;
 import io.julian.server.api.client.ServerClient;
+import io.julian.server.models.control.ServerConfiguration;
 import io.julian.server.models.coordination.CoordinationMessage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.Random;
 
 public abstract class AbstractHandler {
     private final static Logger log = LogManager.getLogger(AbstractHandler.class);
     protected final ServerClient client;
     protected final State state;
+    protected final RegistryManager registry;
+    protected final GossipConfiguration configuration;
 
-    public AbstractHandler(final ServerClient client, final State state) {
+    public AbstractHandler(final ServerClient client, final State state, final RegistryManager registry, final GossipConfiguration configuration) {
         this.client = client;
         this.state = state;
+        this.registry = registry;
+        this.configuration = configuration;
+    }
+
+    protected void dealWithSucceededMessage(final CoordinationMessage message) {
+        log.traceEntry(() -> message);
+        sendToMetricsCollector(200, message);
+        log.traceExit();
+    }
+
+    protected void dealWithFailedMessage(final CoordinationMessage message) {
+        log.traceEntry(() -> message);
+        sendToMetricsCollector(400, message);
+        state.addToDeadLetters(message);
+        log.traceExit();
     }
 
     public void sendToMetricsCollector(final int statusCode, final CoordinationMessage message) {
@@ -28,5 +50,17 @@ public abstract class AbstractHandler {
                 log.error(cause.getMessage());
             });
         log.traceExit();
+    }
+
+    protected ServerConfiguration getNextServer() {
+        log.traceEntry();
+        Random random = new Random();
+        return log.traceExit(registry.getOtherServers().get(random.nextInt(registry.getOtherServers().size())));
+    }
+
+    public boolean shouldBecomeInactive() {
+        log.traceEntry();
+        Random random = new Random();
+        return log.traceExit(random.nextFloat() < configuration.getInactiveProbability());
     }
 }

--- a/gossip/src/main/java/io/julian/gossip/Gossip.java
+++ b/gossip/src/main/java/io/julian/gossip/Gossip.java
@@ -67,4 +67,9 @@ public class Gossip extends DistributedAlgorithm {
         log.traceEntry();
         return log.traceExit(this.configuration);
     }
+
+    public State getState() {
+        log.traceEntry();
+        return log.traceExit(state);
+    }
 }

--- a/gossip/src/main/java/io/julian/gossip/MessageHandler.java
+++ b/gossip/src/main/java/io/julian/gossip/MessageHandler.java
@@ -34,7 +34,7 @@ public class MessageHandler {
                     .compose(v -> writeHandler.forwardPost(messageID)));
             case WriteReplyHandler.WRITE_REPLY_TYPE:
                 UpdateResponse response = message.getDefinition().mapTo(UpdateResponse.class);
-                return log.traceExit(writeHandler.sendMessageIfNotInactive(response));
+                return log.traceExit(writeHandler.sendPostIfNotInactive(response));
         }
         return log.traceExit(Future.succeededFuture());
     }

--- a/gossip/src/main/java/io/julian/gossip/components/State.java
+++ b/gossip/src/main/java/io/julian/gossip/components/State.java
@@ -17,13 +17,15 @@ public class State {
     private final static Logger log = LogManager.getLogger(State.class);
     private final MessageStore messages;
     private final ConcurrentLinkedQueue<CoordinationMessage> deadLetters;
-    private final ConcurrentHashSet<String> inactiveIds;
+    private final ConcurrentHashSet<String> inactivePostIds;
+    private final ConcurrentHashSet<String> inactiveDeleteIds;
     private final ConcurrentHashSet<String> deletedIds;
 
     public State(final MessageStore messages, final ConcurrentLinkedQueue<CoordinationMessage> deadLetters) {
         this.messages = messages;
         this.deadLetters = deadLetters;
-        this.inactiveIds = new ConcurrentHashSet<>();
+        this.inactivePostIds = new ConcurrentHashSet<>();
+        this.inactiveDeleteIds = new ConcurrentHashSet<>();
         this.deletedIds = new ConcurrentHashSet<>();
     }
 
@@ -102,19 +104,36 @@ public class State {
         return log.traceExit(deletedIds);
     }
 
-    public void addInactiveId(final String id) {
+    public void addInactivePostId(final String id) {
         log.traceEntry(() -> id);
-        inactiveIds.add(id);
+        inactivePostIds.add(id);
         log.traceExit();
     }
 
-    public boolean isInactiveId(final String id) {
+    public boolean isInactivePostId(final String id) {
         log.traceEntry(() -> id);
-        return log.traceExit(inactiveIds.contains(id));
+        return log.traceExit(inactivePostIds.contains(id));
     }
 
-    public ConcurrentHashSet<String> getInactiveIds() {
+    public ConcurrentHashSet<String> getInactivePostIds() {
         log.traceEntry();
-        return log.traceExit(inactiveIds);
+        return log.traceExit(inactivePostIds);
     }
+
+    public void addInactiveDeleteId(final String id) {
+        log.traceEntry(() -> id);
+        inactiveDeleteIds.add(id);
+        log.traceExit();
+    }
+
+    public boolean isInactiveDeleteId(final String id) {
+        log.traceEntry(() -> id);
+        return log.traceExit(inactiveDeleteIds.contains(id));
+    }
+
+    public ConcurrentHashSet<String> getInactiveDeleteIds() {
+        log.traceEntry();
+        return log.traceExit(inactiveDeleteIds);
+    }
+
 }

--- a/gossip/src/main/java/io/julian/gossip/components/State.java
+++ b/gossip/src/main/java/io/julian/gossip/components/State.java
@@ -1,6 +1,7 @@
 package io.julian.gossip.components;
 
 import io.julian.gossip.models.MessageUpdate;
+import io.julian.server.api.exceptions.NoIDException;
 import io.julian.server.api.exceptions.SameIDException;
 import io.julian.server.components.MessageStore;
 import io.julian.server.models.coordination.CoordinationMessage;
@@ -16,12 +17,14 @@ public class State {
     private final static Logger log = LogManager.getLogger(State.class);
     private final MessageStore messages;
     private final ConcurrentLinkedQueue<CoordinationMessage> deadLetters;
-    private final ConcurrentHashSet<String> inactiveKeys;
+    private final ConcurrentHashSet<String> inactiveIds;
+    private final ConcurrentHashSet<String> deletedIds;
 
     public State(final MessageStore messages, final ConcurrentLinkedQueue<CoordinationMessage> deadLetters) {
         this.messages = messages;
         this.deadLetters = deadLetters;
-        this.inactiveKeys = new ConcurrentHashSet<>();
+        this.inactiveIds = new ConcurrentHashSet<>();
+        this.deletedIds = new ConcurrentHashSet<>();
     }
 
     public MessageStore getMessages() {
@@ -37,10 +40,30 @@ public class State {
 
     public void addMessageIfNotInDatabase(final String messageId, final JsonObject message) {
         log.traceEntry(() -> messageId, () -> message);
-        try {
-            messages.addMessageToServer(messageId, message);
-        } catch (final SameIDException e) {
-            log.info(String.format("Skipping adding '%s' message to server", messageId));
+        if (!deletedIds.contains(messageId)) {
+            try {
+                messages.addMessageToServer(messageId, message);
+            } catch (final SameIDException e) {
+                log.info(String.format("Skipping adding '%s' message to server", messageId));
+            }
+        } else {
+            log.info(String.format("Skipping adding '%s' message as it is a deleted key", messageId));
+        }
+        log.traceExit();
+    }
+
+    public void deleteMessageIfInDatabase(final String messageId) {
+        log.traceEntry(() -> messageId);
+        log.info(String.format("Attempting to delete '%s'", messageId));
+        if (messages.hasUUID(messageId)) {
+            addDeletedId(messageId);
+            try {
+                messages.deleteMessageFromServer(messageId);
+            } catch (final NoIDException e) {
+                log.info(String.format("Did not delete '%s' as it is already deleted", messageId));
+            }
+        } else {
+            log.info(String.format("Did not delete '%s' as it is already deleted", messageId));
         }
         log.traceExit();
     }
@@ -56,19 +79,42 @@ public class State {
         return log.traceExit(array);
     }
 
-    public void addInactiveKey(final String key) {
-        log.traceEntry(() -> key);
-        inactiveKeys.add(key);
+    public JsonArray getDeletedArray() {
+        log.traceEntry();
+        final JsonArray array = new JsonArray();
+        deletedIds.forEach(array::add);
+        return log.traceExit(array);
+    }
+
+    public void addDeletedId(final String id) {
+        log.traceEntry(() -> id);
+        deletedIds.add(id);
         log.traceExit();
     }
 
-    public boolean isAnInactiveKey(final String key) {
-        log.traceEntry(() -> key);
-        return log.traceExit(inactiveKeys.contains(key));
+    public boolean isDeletedId(final String id) {
+        log.traceEntry(() -> id);
+        return log.traceExit(deletedIds.contains(id));
     }
 
-    public ConcurrentHashSet<String> getInactiveKeys() {
+    public ConcurrentHashSet<String> getDeletedIds() {
         log.traceEntry();
-        return log.traceExit(inactiveKeys);
+        return log.traceExit(deletedIds);
+    }
+
+    public void addInactiveId(final String id) {
+        log.traceEntry(() -> id);
+        inactiveIds.add(id);
+        log.traceExit();
+    }
+
+    public boolean isInactiveId(final String id) {
+        log.traceEntry(() -> id);
+        return log.traceExit(inactiveIds.contains(id));
+    }
+
+    public ConcurrentHashSet<String> getInactiveIds() {
+        log.traceEntry();
+        return log.traceExit(inactiveIds);
     }
 }

--- a/gossip/src/main/java/io/julian/gossip/delete/DeleteHandler.java
+++ b/gossip/src/main/java/io/julian/gossip/delete/DeleteHandler.java
@@ -1,0 +1,70 @@
+package io.julian.gossip.delete;
+
+import io.julian.gossip.AbstractHandler;
+import io.julian.gossip.components.GossipConfiguration;
+import io.julian.gossip.components.State;
+import io.julian.server.api.client.RegistryManager;
+import io.julian.server.api.client.ServerClient;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.control.ClientMessage;
+import io.julian.server.models.control.ServerConfiguration;
+import io.julian.server.models.coordination.CoordinationMessage;
+import io.julian.server.models.coordination.CoordinationMetadata;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class DeleteHandler extends AbstractHandler {
+    private final static Logger log = LogManager.getLogger(DeleteHandler.class);
+    private final ServerConfiguration serverConfiguration;
+
+    public final static String TYPE = "deleteRequest";
+
+    public DeleteHandler(final ServerClient client, final State state, final RegistryManager registry, final GossipConfiguration configuration, final ServerConfiguration serverConfiguration) {
+        super(client, state, registry, configuration);
+        this.serverConfiguration = serverConfiguration;
+    }
+
+    public Future<Void> dealWithClientMessage(final ClientMessage message) {
+        log.traceEntry(() -> message);
+        state.deleteMessageIfInDatabase(message.getMessageId());
+        return log.traceExit(sendMessage(getCoordinationMessage(message.getMessageId())));
+    }
+
+    public Future<Void> forwardDelete(final String messageId) {
+        log.traceEntry(() -> messageId);
+        state.deleteMessageIfInDatabase(messageId);
+        return log.traceExit(sendMessage(getCoordinationMessage(messageId)));
+    }
+
+    private Future<Void> sendMessage(final CoordinationMessage message) {
+        log.traceEntry(() -> message);
+        Promise<Void> delete = Promise.promise();
+        final ServerConfiguration toServer = getNextServer();
+        log.info(String.format("Attempting to forward '%s' of '%s' to '%s'", TYPE, message.getMetadata(), toServer));
+
+        client.sendCoordinateMessageToServer(toServer, message)
+            .onSuccess(v -> {
+                log.info(String.format("Successfully forwarded '%s' of '%s' to '%s'", TYPE, message.getMetadata(), toServer));
+                dealWithSucceededMessage(message);
+                delete.complete();
+            })
+            .onFailure(cause -> {
+                log.info(String.format("Failed to forward '%s' of '%s' to '%s'", TYPE, message.getMetadata(), toServer));
+                log.error(cause);
+                dealWithFailedMessage(message);
+                delete.fail(cause);
+            });
+
+        return log.traceExit(delete.future());
+    }
+
+    public CoordinationMessage getCoordinationMessage(final String messageId) {
+        log.traceEntry();
+        return log.traceExit(new CoordinationMessage(
+            new CoordinationMetadata(HTTPRequest.DELETE, messageId, TYPE),
+            null,
+            serverConfiguration.toJson()));
+    }
+}

--- a/gossip/src/main/java/io/julian/gossip/delete/DeleteReplyHandler.java
+++ b/gossip/src/main/java/io/julian/gossip/delete/DeleteReplyHandler.java
@@ -1,0 +1,52 @@
+package io.julian.gossip.delete;
+
+import io.julian.gossip.AbstractHandler;
+import io.julian.gossip.components.GossipConfiguration;
+import io.julian.gossip.components.State;
+import io.julian.gossip.models.UpdateResponse;
+import io.julian.server.api.client.RegistryManager;
+import io.julian.server.api.client.ServerClient;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.control.ServerConfiguration;
+import io.julian.server.models.coordination.CoordinationMessage;
+import io.julian.server.models.coordination.CoordinationMetadata;
+import io.vertx.core.Future;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class DeleteReplyHandler extends AbstractHandler {
+    private final static Logger log = LogManager.getLogger(DeleteReplyHandler.class);
+
+    public final static String TYPE = "deleteReply";
+
+    public DeleteReplyHandler(final ServerClient client, final State state, final RegistryManager registry, final GossipConfiguration configuration) {
+        super(client, state, registry, configuration);
+    }
+
+    public Future<Void> handleReply(final String messageId, final ServerConfiguration toServer) {
+        log.traceEntry(() -> messageId, () -> toServer);
+
+        boolean hasProcessed = true;
+        if (state.getMessages().hasUUID(messageId)) {
+            state.deleteMessageIfInDatabase(messageId);
+            hasProcessed = false;
+        }
+        log.info(String.format("Attempting to reply delete to '%s' about '%s'", toServer.toString(), messageId));
+
+        CoordinationMessage sentMessage = getCoordinationMessage(messageId, hasProcessed);
+        return log.traceExit(sendResponseToServer(
+            toServer,
+            sentMessage,
+            String.format("Successfully replied to delete '%s' about '%s'", toServer.toString(), messageId),
+            String.format("Failed to reply delete to '%s' about '%s'", toServer.toString(), messageId)));
+    }
+
+    public CoordinationMessage getCoordinationMessage(final String messageId, final boolean hasProcessedId) {
+        log.traceEntry(() -> messageId, () -> hasProcessedId);
+        return log.traceExit(new CoordinationMessage(
+            new CoordinationMetadata(HTTPRequest.DELETE, String.format("%s-delete-reply", messageId), TYPE),
+            null,
+            new UpdateResponse(messageId, hasProcessedId).toJson()
+        ));
+    }
+}

--- a/gossip/src/main/java/io/julian/gossip/delete/DeleteReplyHandler.java
+++ b/gossip/src/main/java/io/julian/gossip/delete/DeleteReplyHandler.java
@@ -17,7 +17,7 @@ import org.apache.logging.log4j.Logger;
 public class DeleteReplyHandler extends AbstractHandler {
     private final static Logger log = LogManager.getLogger(DeleteReplyHandler.class);
 
-    public final static String TYPE = "deleteReply";
+    public final static String DELETE_REPLY_TYPE = "deleteReply";
 
     public DeleteReplyHandler(final ServerClient client, final State state, final RegistryManager registry, final GossipConfiguration configuration) {
         super(client, state, registry, configuration);
@@ -44,7 +44,7 @@ public class DeleteReplyHandler extends AbstractHandler {
     public CoordinationMessage getCoordinationMessage(final String messageId, final boolean hasProcessedId) {
         log.traceEntry(() -> messageId, () -> hasProcessedId);
         return log.traceExit(new CoordinationMessage(
-            new CoordinationMetadata(HTTPRequest.DELETE, String.format("%s-delete-reply", messageId), TYPE),
+            new CoordinationMetadata(HTTPRequest.DELETE, String.format("%s-delete-reply", messageId), DELETE_REPLY_TYPE),
             null,
             new UpdateResponse(messageId, hasProcessedId).toJson()
         ));

--- a/gossip/src/main/java/io/julian/gossip/models/UpdateResponse.java
+++ b/gossip/src/main/java/io/julian/gossip/models/UpdateResponse.java
@@ -12,21 +12,21 @@ import org.apache.logging.log4j.Logger;
 public class UpdateResponse {
     private final static Logger log = LogManager.getLogger(UpdateResponse.class);
     public final static String MESSAGE_ID_KEY = "messageId";
-    public final static String DOES_CONTAIN_ID_KEY = "doesContainId";
+    public final static String HAS_PROCESSED_ID_KEY = "hasProcessedId";
 
     private String messageId;
-    private Boolean doesContainId;
+    private Boolean hasProcessedId;
 
     public UpdateResponse(@JsonProperty(MESSAGE_ID_KEY) final String messageId,
-                          @JsonProperty(DOES_CONTAIN_ID_KEY) final Boolean doesContainId) {
+                          @JsonProperty(HAS_PROCESSED_ID_KEY) final Boolean hasProcessedId) {
         this.messageId = messageId;
-        this.doesContainId = doesContainId;
+        this.hasProcessedId = hasProcessedId;
     }
 
     public JsonObject toJson() {
         log.traceEntry();
         return log.traceExit(new JsonObject()
             .put(MESSAGE_ID_KEY, messageId)
-            .put(DOES_CONTAIN_ID_KEY, doesContainId));
+            .put(HAS_PROCESSED_ID_KEY, hasProcessedId));
     }
 }

--- a/gossip/src/main/java/io/julian/gossip/write/WriteReplyHandler.java
+++ b/gossip/src/main/java/io/julian/gossip/write/WriteReplyHandler.java
@@ -11,7 +11,6 @@ import io.julian.server.models.control.ServerConfiguration;
 import io.julian.server.models.coordination.CoordinationMessage;
 import io.julian.server.models.coordination.CoordinationMetadata;
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -26,30 +25,21 @@ public class WriteReplyHandler extends AbstractHandler {
 
     public Future<Void> handleReply(final String messageId, final JsonObject message, final ServerConfiguration toServer) {
         log.traceEntry(() -> messageId, () -> message, () -> toServer);
-        Promise<Void> reply = Promise.promise();
 
         boolean hasMessage = true;
         if (!state.getMessages().hasUUID(messageId)) {
             state.addMessageIfNotInDatabase(messageId, message);
             hasMessage = false;
         }
-        log.info(String.format("Attempting to reply to '%s' about '%s'", toServer.toString(), messageId));
+        log.info(String.format("Attempting to reply post to '%s' about '%s'", toServer.toString(), messageId));
 
         CoordinationMessage sentMessage = getCoordinationMessage(messageId, hasMessage);
-        client.sendCoordinateMessageToServer(toServer, sentMessage)
-            .onSuccess(v -> {
-                log.info(String.format("Successfully replied to '%s' about '%s'", toServer.toString(), messageId));
-                dealWithSucceededMessage(sentMessage);
-                reply.complete();
-            })
-            .onFailure(cause -> {
-                log.info(String.format("Failed to reply to '%s' about '%s'", toServer.toString(), messageId));
-                log.error(cause);
-                dealWithFailedMessage(sentMessage);
-                reply.fail(cause);
-            });
 
-        return log.traceExit(reply.future());
+        return log.traceExit(sendResponseToServer(
+            toServer,
+            sentMessage,
+            String.format("Successfully replied post to '%s' about '%s'", toServer.toString(), messageId),
+            String.format("Failed to reply post to '%s' about '%s'", toServer.toString(), messageId)));
     }
 
     public CoordinationMessage getCoordinationMessage(final String messageId, final boolean hasMessage) {

--- a/gossip/src/test/java/io/julian/gossip/MessageHandlerTest.java
+++ b/gossip/src/test/java/io/julian/gossip/MessageHandlerTest.java
@@ -24,7 +24,7 @@ public class MessageHandlerTest extends AbstractHandlerTest {
     @Test
     public void TestMessageHandlerRepliesAndSendsMessage(final TestContext context) {
         TestMetricsCollector collector = setUpMetricsCollector(context);
-        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        TestServerComponents server = setUpBasicApiServer(context);
         MessageStore messages = new MessageStore();
         MessageHandler handler = createTestMessageHandler(createState(messages));
         ClientMessage message = new ClientMessage(HTTPRequest.POST, new JsonObject(), MESSAGE_ID);
@@ -48,7 +48,7 @@ public class MessageHandlerTest extends AbstractHandlerTest {
     @Test
     public void TestMessageHandlerReplies(final TestContext context) {
         TestMetricsCollector collector = setUpMetricsCollector(context);
-        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        TestServerComponents server = setUpBasicApiServer(context);
         MessageStore messages = new MessageStore();
         messages.putMessage(MESSAGE_ID, new JsonObject());
         MessageHandler handler = createTestMessageHandler(createState(messages));
@@ -71,7 +71,7 @@ public class MessageHandlerTest extends AbstractHandlerTest {
     @Test
     public void TestMessageHandlerDealsWithClientMessage(final TestContext context) {
         TestMetricsCollector collector = setUpMetricsCollector(context);
-        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        TestServerComponents server = setUpBasicApiServer(context);
         MessageStore messages = new MessageStore();
         MessageHandler handler = createTestMessageHandler(createState(messages));
         ClientMessage message = new ClientMessage(HTTPRequest.POST, new JsonObject(), MESSAGE_ID);

--- a/gossip/src/test/java/io/julian/gossip/MessageHandlerTest.java
+++ b/gossip/src/test/java/io/julian/gossip/MessageHandlerTest.java
@@ -2,6 +2,8 @@ package io.julian.gossip;
 
 import io.julian.gossip.components.GossipConfiguration;
 import io.julian.gossip.components.State;
+import io.julian.gossip.delete.DeleteHandler;
+import io.julian.gossip.delete.DeleteReplyHandler;
 import io.julian.gossip.models.UpdateResponse;
 import io.julian.gossip.write.WriteHandler;
 import io.julian.gossip.write.WriteReplyHandler;
@@ -21,8 +23,9 @@ import tools.TestServerComponents;
 
 public class MessageHandlerTest extends AbstractHandlerTest {
     private final static String MESSAGE_ID = "id";
+
     @Test
-    public void TestMessageHandlerRepliesAndSendsMessage(final TestContext context) {
+    public void TestMessageHandlerRepliesAndSendsMessagePost(final TestContext context) {
         TestMetricsCollector collector = setUpMetricsCollector(context);
         TestServerComponents server = setUpBasicApiServer(context);
         MessageStore messages = new MessageStore();
@@ -46,7 +49,7 @@ public class MessageHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void TestMessageHandlerReplies(final TestContext context) {
+    public void TestMessageHandlerRepliesPost(final TestContext context) {
         TestMetricsCollector collector = setUpMetricsCollector(context);
         TestServerComponents server = setUpBasicApiServer(context);
         MessageStore messages = new MessageStore();
@@ -69,7 +72,7 @@ public class MessageHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void TestMessageHandlerDealsWithClientMessage(final TestContext context) {
+    public void TestMessageHandlerDealsWithClientMessagePost(final TestContext context) {
         TestMetricsCollector collector = setUpMetricsCollector(context);
         TestServerComponents server = setUpBasicApiServer(context);
         MessageStore messages = new MessageStore();
@@ -81,6 +84,75 @@ public class MessageHandlerTest extends AbstractHandlerTest {
             .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(500, v1 -> {
                 collector.testHasExpectedStatusSize(1);
                 Assert.assertEquals(1, messages.getNumberOfMessages());
+                async.complete();
+            })));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+        collector.tearDownMetricsCollector(context);
+    }
+
+    @Test
+    public void TestMessageHandlerRepliesAndSendsMessageDeleete(final TestContext context) {
+        TestMetricsCollector collector = setUpMetricsCollector(context);
+        TestServerComponents server = setUpBasicApiServer(context);
+        MessageStore messages = new MessageStore();
+        messages.putMessage(MESSAGE_ID, new JsonObject());
+        MessageHandler handler = createTestMessageHandler(createState(messages));
+        ClientMessage message = new ClientMessage(HTTPRequest.DELETE, new JsonObject(), MESSAGE_ID);
+        CoordinationMessage response = new CoordinationMessage(
+            new CoordinationMetadata(HTTPRequest.POST, "id", DeleteHandler.DELETE_UPDATE_TYPE),
+            message.toJson(),
+            DEFAULT_SEVER_CONFIG.toJson());
+
+        Async async = context.async();
+        handler.handleCoordinationMessage(response)
+            .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(500, v1 -> {
+                collector.testHasExpectedStatusSize(2);
+                Assert.assertEquals(0, messages.getNumberOfMessages());
+                async.complete();
+            })));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+        collector.tearDownMetricsCollector(context);
+    }
+
+    @Test
+    public void TestMessageHandlerRepliesDelete(final TestContext context) {
+        TestMetricsCollector collector = setUpMetricsCollector(context);
+        TestServerComponents server = setUpBasicApiServer(context);
+        MessageStore messages = new MessageStore();
+        MessageHandler handler = createTestMessageHandler(createState(messages));
+        CoordinationMessage message = new CoordinationMessage(
+            new CoordinationMetadata(HTTPRequest.DELETE, MESSAGE_ID, DeleteReplyHandler.DELETE_REPLY_TYPE),
+            null,
+            new UpdateResponse(MESSAGE_ID, false).toJson());
+
+        Async async = context.async();
+        handler.handleCoordinationMessage(message)
+            .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(1000, v1 -> {
+                collector.testHasExpectedStatusSize(1);
+                Assert.assertEquals(0, messages.getNumberOfMessages());
+                async.complete();
+            })));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+        collector.tearDownMetricsCollector(context);
+    }
+
+    @Test
+    public void TestMessageHandlerDealsWithClientMessageDelete(final TestContext context) {
+        TestMetricsCollector collector = setUpMetricsCollector(context);
+        TestServerComponents server = setUpBasicApiServer(context);
+        MessageStore messages = new MessageStore();
+        messages.putMessage(MESSAGE_ID, new JsonObject());
+        MessageHandler handler = createTestMessageHandler(createState(messages));
+        ClientMessage message = new ClientMessage(HTTPRequest.DELETE, new JsonObject(), MESSAGE_ID);
+
+        Async async = context.async();
+        handler.handleClientMessage(message)
+            .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(500, v1 -> {
+                collector.testHasExpectedStatusSize(1);
+                Assert.assertEquals(0, messages.getNumberOfMessages());
                 async.complete();
             })));
         async.awaitSuccess();

--- a/gossip/src/test/java/io/julian/gossip/components/StateTest.java
+++ b/gossip/src/test/java/io/julian/gossip/components/StateTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public class StateTest {
     private final static String MESSAGE_ID = "messageId";
     private final static JsonObject MESSAGE = new JsonObject().put("test", new JsonObject().put("nested", "key"));
+    private final static String DELETED_ID = "deletedId";
 
     @Test
     public void TestInit() {
@@ -31,6 +32,15 @@ public class StateTest {
         JsonArray array = state.getMessageArray();
         Assert.assertEquals(1, array.size());
         Assert.assertEquals(new MessageUpdate(MESSAGE_ID, MESSAGE).toJson().encodePrettily(), array.getJsonObject(0).encodePrettily());
+    }
+
+    @Test
+    public void TestGetDeletedArray() {
+        State state = new State(new MessageStore(), new ConcurrentLinkedQueue<>());
+        state.addDeletedId(DELETED_ID);
+        JsonArray array = state.getDeletedArray();
+        Assert.assertEquals(1, array.size());
+        Assert.assertEquals(DELETED_ID, array.getString(0));
     }
 
     @Test
@@ -53,27 +63,62 @@ public class StateTest {
         Assert.assertEquals(1, state.getMessages().getNumberOfMessages());
         state.addMessageIfNotInDatabase(MESSAGE_ID, MESSAGE);
         Assert.assertEquals(1, state.getMessages().getNumberOfMessages());
+
+        state.addDeletedId(DELETED_ID);
+        state.addMessageIfNotInDatabase(DELETED_ID, MESSAGE);
+        Assert.assertEquals(1, state.getMessages().getNumberOfMessages());
     }
 
     @Test
-    public void TestAddMessageInActiveKey() {
+    public void TestDeleteMessageIfInDatabase() {
         MessageStore messages = new MessageStore();
         State state = new State(messages,  new ConcurrentLinkedQueue<>());
-        Assert.assertEquals(0, state.getInactiveKeys().size());
+        state.addMessageIfNotInDatabase(MESSAGE_ID, MESSAGE);
+        Assert.assertEquals(1, state.getMessages().getNumberOfMessages());
 
-        state.addInactiveKey(MESSAGE_ID);
-        Assert.assertEquals(1, state.getInactiveKeys().size());
-        state.addInactiveKey(MESSAGE_ID);
-        Assert.assertEquals(1, state.getInactiveKeys().size());
+        state.deleteMessageIfInDatabase(MESSAGE_ID);
+        Assert.assertEquals(0, state.getMessages().getNumberOfMessages());
+        state.deleteMessageIfInDatabase(MESSAGE_ID);
+        Assert.assertEquals(0, state.getMessages().getNumberOfMessages());
     }
 
     @Test
-    public void TestIsAnInactiveKey() {
-        MessageStore messages = new MessageStore();
-        State state = new State(messages,  new ConcurrentLinkedQueue<>());
+    public void TestAddInactiveId() {
+        State state = new State(new MessageStore(),  new ConcurrentLinkedQueue<>());
+        Assert.assertEquals(0, state.getInactiveIds().size());
 
-        Assert.assertFalse(state.isAnInactiveKey(MESSAGE_ID));
-        state.addInactiveKey(MESSAGE_ID);
-        Assert.assertTrue(state.isAnInactiveKey(MESSAGE_ID));
+        state.addInactiveId(MESSAGE_ID);
+        Assert.assertEquals(1, state.getInactiveIds().size());
+        state.addInactiveId(MESSAGE_ID);
+        Assert.assertEquals(1, state.getInactiveIds().size());
+    }
+
+    @Test
+    public void TestIsInactiveId() {
+        State state = new State(new MessageStore(),  new ConcurrentLinkedQueue<>());
+
+        Assert.assertFalse(state.isInactiveId(MESSAGE_ID));
+        state.addInactiveId(MESSAGE_ID);
+        Assert.assertTrue(state.isInactiveId(MESSAGE_ID));
+    }
+
+    @Test
+    public void TestAddDeletedId() {
+        State state = new State(new MessageStore(),  new ConcurrentLinkedQueue<>());
+        Assert.assertEquals(0, state.getInactiveIds().size());
+
+        state.addDeletedId(MESSAGE_ID);
+        Assert.assertEquals(1, state.getDeletedIds().size());
+        state.addDeletedId(MESSAGE_ID);
+        Assert.assertEquals(1, state.getDeletedIds().size());
+    }
+
+    @Test
+    public void TestIsDeletedId() {
+        State state = new State(new MessageStore(),  new ConcurrentLinkedQueue<>());
+
+        Assert.assertFalse(state.isDeletedId(MESSAGE_ID));
+        state.addDeletedId(MESSAGE_ID);
+        Assert.assertTrue(state.isDeletedId(MESSAGE_ID));
     }
 }

--- a/gossip/src/test/java/io/julian/gossip/components/StateTest.java
+++ b/gossip/src/test/java/io/julian/gossip/components/StateTest.java
@@ -83,29 +83,49 @@ public class StateTest {
     }
 
     @Test
-    public void TestAddInactiveId() {
+    public void TestAddInactivePostId() {
         State state = new State(new MessageStore(),  new ConcurrentLinkedQueue<>());
-        Assert.assertEquals(0, state.getInactiveIds().size());
+        Assert.assertEquals(0, state.getInactivePostIds().size());
 
-        state.addInactiveId(MESSAGE_ID);
-        Assert.assertEquals(1, state.getInactiveIds().size());
-        state.addInactiveId(MESSAGE_ID);
-        Assert.assertEquals(1, state.getInactiveIds().size());
+        state.addInactivePostId(MESSAGE_ID);
+        Assert.assertEquals(1, state.getInactivePostIds().size());
+        state.addInactivePostId(MESSAGE_ID);
+        Assert.assertEquals(1, state.getInactivePostIds().size());
     }
 
     @Test
-    public void TestIsInactiveId() {
+    public void TestIsInactivePostId() {
         State state = new State(new MessageStore(),  new ConcurrentLinkedQueue<>());
 
-        Assert.assertFalse(state.isInactiveId(MESSAGE_ID));
-        state.addInactiveId(MESSAGE_ID);
-        Assert.assertTrue(state.isInactiveId(MESSAGE_ID));
+        Assert.assertFalse(state.isInactivePostId(MESSAGE_ID));
+        state.addInactivePostId(MESSAGE_ID);
+        Assert.assertTrue(state.isInactivePostId(MESSAGE_ID));
+    }
+
+    @Test
+    public void TestAddInactiveDeleteId() {
+        State state = new State(new MessageStore(),  new ConcurrentLinkedQueue<>());
+        Assert.assertEquals(0, state.getInactiveDeleteIds().size());
+
+        state.addInactiveDeleteId(MESSAGE_ID);
+        Assert.assertEquals(1, state.getInactiveDeleteIds().size());
+        state.addInactiveDeleteId(MESSAGE_ID);
+        Assert.assertEquals(1, state.getInactiveDeleteIds().size());
+    }
+
+    @Test
+    public void TestIsInactiveDeleteId() {
+        State state = new State(new MessageStore(),  new ConcurrentLinkedQueue<>());
+
+        Assert.assertFalse(state.isInactiveDeleteId(MESSAGE_ID));
+        state.addInactiveDeleteId(MESSAGE_ID);
+        Assert.assertTrue(state.isInactiveDeleteId(MESSAGE_ID));
     }
 
     @Test
     public void TestAddDeletedId() {
         State state = new State(new MessageStore(),  new ConcurrentLinkedQueue<>());
-        Assert.assertEquals(0, state.getInactiveIds().size());
+        Assert.assertEquals(0, state.getInactivePostIds().size());
 
         state.addDeletedId(MESSAGE_ID);
         Assert.assertEquals(1, state.getDeletedIds().size());

--- a/gossip/src/test/java/io/julian/gossip/delete/DeleteHandlerTest.java
+++ b/gossip/src/test/java/io/julian/gossip/delete/DeleteHandlerTest.java
@@ -1,0 +1,128 @@
+package io.julian.gossip.delete;
+
+import io.julian.gossip.components.GossipConfiguration;
+import io.julian.gossip.components.State;
+import io.julian.server.components.MessageStore;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.control.ClientMessage;
+import io.julian.server.models.coordination.CoordinationMessage;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Assert;
+import org.junit.Test;
+import tools.AbstractHandlerTest;
+import tools.TestMetricsCollector;
+import tools.TestServerComponents;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class DeleteHandlerTest extends AbstractHandlerTest {
+    private final static String DELETE_ID = "delete-id";
+
+    @Test
+    public void TestGetCoordinationMessage() {
+        DeleteHandler deleteHandler = getDeleteHandler(createState());
+        CoordinationMessage message = deleteHandler.getCoordinationMessage(DELETE_ID);
+        Assert.assertEquals(HTTPRequest.DELETE, message.getMetadata().getRequest());
+        Assert.assertEquals(DELETE_ID, message.getMetadata().getMessageID());
+        Assert.assertEquals(DeleteHandler.TYPE, message.getMetadata().getType());
+        Assert.assertEquals(DEFAULT_SEVER_CONFIG.toJson().encodePrettily(), message.getDefinition().encodePrettily());
+        Assert.assertNull(message.getMessage());
+    }
+
+    @Test
+    public void TestDealWithClientRequestSucceeds(final TestContext context) {
+        TestMetricsCollector collector = setUpMetricsCollector(context);
+        TestServerComponents server = setUpBasicApiServer(context);
+
+        ConcurrentLinkedQueue<CoordinationMessage> deadLetter = new ConcurrentLinkedQueue<>();
+        MessageStore messageStore = new MessageStore();
+        messageStore.putMessage(DELETE_ID, new JsonObject());
+        DeleteHandler deleteHandler = getDeleteHandler(createState(messageStore, deadLetter));
+
+        Async async = context.async();
+        deleteHandler.dealWithClientMessage(new ClientMessage(HTTPRequest.DELETE, new JsonObject(), DELETE_ID))
+            .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(1000, v1 -> {
+                Assert.assertEquals(0, messageStore.getNumberOfMessages());
+                Assert.assertEquals(0, deadLetter.size());
+                collector.testHasExpectedStatusSize(1);
+                async.complete();
+            })));
+
+        async.awaitSuccess();
+        tearDownServer(context, server);
+        collector.tearDownMetricsCollector(context);
+    }
+
+    @Test
+    public void TestForwardDeleteRequestSucceeds(final TestContext context) {
+        TestMetricsCollector collector = setUpMetricsCollector(context);
+        TestServerComponents server = setUpBasicApiServer(context);
+
+        MessageStore messageStore = new MessageStore();
+        messageStore.putMessage(DELETE_ID, new JsonObject());
+        ConcurrentLinkedQueue<CoordinationMessage> deadLetter = new ConcurrentLinkedQueue<>();
+        DeleteHandler deleteHandler = getDeleteHandler(createState(messageStore, deadLetter));
+
+        Async async = context.async();
+        deleteHandler.forwardDelete(DELETE_ID)
+            .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(1000, v1 -> {
+                Assert.assertEquals(0, deadLetter.size());
+                Assert.assertEquals(0, messageStore.getNumberOfMessages());
+                collector.testHasExpectedStatusSize(1);
+                async.complete();
+            })));
+
+        async.awaitSuccess();
+        tearDownServer(context, server);
+        collector.tearDownMetricsCollector(context);
+    }
+
+    @Test
+    public void TestDeleteHandlerFails(final TestContext context) {
+        TestMetricsCollector collector = setUpMetricsCollector(context);
+        ConcurrentLinkedQueue<CoordinationMessage> deadLetter = new ConcurrentLinkedQueue<>();
+        MessageStore messageStore = new MessageStore();
+        messageStore.putMessage(DELETE_ID, new JsonObject());
+        DeleteHandler deleteHandler = getDeleteHandler(createState(messageStore, deadLetter));
+
+        Async async = context.async();
+        deleteHandler.forwardDelete(DELETE_ID)
+            .onComplete(context.asyncAssertFailure(cause -> vertx.setTimer(1000, v1 -> {
+                Assert.assertEquals(1, deadLetter.size());
+                Assert.assertEquals(0, messageStore.getNumberOfMessages());
+                collector.testHasExpectedStatusSize(1);
+                Assert.assertEquals(CONNECTION_REFUSED_EXCEPTION, cause.getMessage());
+                async.complete();
+            })));
+
+        async.awaitSuccess();
+        collector.tearDownMetricsCollector(context);
+    }
+
+    @Test
+    public void TestDeleteHandlerDoesNotErrorWhenDeletingNullKey(final TestContext context) {
+        TestMetricsCollector collector = setUpMetricsCollector(context);
+        ConcurrentLinkedQueue<CoordinationMessage> deadLetter = new ConcurrentLinkedQueue<>();
+        MessageStore messageStore = new MessageStore();
+        DeleteHandler deleteHandler = getDeleteHandler(createState(messageStore, deadLetter));
+
+        Async async = context.async();
+        deleteHandler.forwardDelete(DELETE_ID)
+            .onComplete(context.asyncAssertFailure(cause -> vertx.setTimer(1000, v1 -> {
+                Assert.assertEquals(1, deadLetter.size());
+                Assert.assertEquals(0, messageStore.getNumberOfMessages());
+                collector.testHasExpectedStatusSize(1);
+                Assert.assertEquals(CONNECTION_REFUSED_EXCEPTION, cause.getMessage());
+                async.complete();
+            })));
+
+        async.awaitSuccess();
+        collector.tearDownMetricsCollector(context);
+    }
+
+    private DeleteHandler getDeleteHandler(final State state) {
+        return new DeleteHandler(createServerClient(), state, createTestRegistryManager(), new GossipConfiguration(), DEFAULT_SEVER_CONFIG);
+    }
+}

--- a/gossip/src/test/java/io/julian/gossip/delete/DeleteReplyHandlerTest.java
+++ b/gossip/src/test/java/io/julian/gossip/delete/DeleteReplyHandlerTest.java
@@ -1,0 +1,104 @@
+package io.julian.gossip.delete;
+
+import io.julian.gossip.components.GossipConfiguration;
+import io.julian.gossip.components.State;
+import io.julian.gossip.models.UpdateResponse;
+import io.julian.server.models.HTTPRequest;
+import io.julian.server.models.coordination.CoordinationMessage;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import org.junit.Assert;
+import org.junit.Test;
+import tools.AbstractHandlerTest;
+import tools.TestMetricsCollector;
+import tools.TestServerComponents;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class DeleteReplyHandlerTest extends AbstractHandlerTest {
+    private final static String DELETE_ID = "deleted-id";
+    private final static boolean HAS_PROCESSED = true;
+
+    @Test
+    public void TestGetCoordinationMessage() {
+        DeleteReplyHandler handler = getDeleteReplyHandler();
+        CoordinationMessage message = handler.getCoordinationMessage(DELETE_ID, HAS_PROCESSED);
+
+        Assert.assertEquals(HTTPRequest.DELETE, message.getMetadata().getRequest());
+        Assert.assertEquals(DeleteReplyHandler.TYPE, message.getMetadata().getType());
+        Assert.assertEquals(DELETE_ID + "-delete-reply", message.getMetadata().getMessageID());
+        Assert.assertEquals(new UpdateResponse(DELETE_ID, HAS_PROCESSED).toJson().encodePrettily(), message.getDefinition().encodePrettily());
+    }
+
+    @Test
+    public void TestHandleReplyCompletesSuccessfullyHandler(final TestContext context) {
+        TestServerComponents server = setUpBasicApiServer(context);
+        TestMetricsCollector metricsCollector = setUpMetricsCollector(context);
+        ConcurrentLinkedQueue<CoordinationMessage> deadLetter = new ConcurrentLinkedQueue<>();
+        State state = createState(deadLetter);
+        DeleteReplyHandler handler = getDeleteReplyHandler(state);
+        state.addMessageIfNotInDatabase(DELETE_ID, new JsonObject());
+
+        Async async = context.async();
+        handler.handleReply(DELETE_ID, DEFAULT_SEVER_CONFIG)
+            .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(1000, v1 -> {
+                metricsCollector.testHasExpectedStatusSize(1);
+                Assert.assertEquals(0, state.getMessages().getNumberOfMessages());
+                Assert.assertEquals(0, deadLetter.size());
+                async.complete();
+            })));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+        metricsCollector.tearDownMetricsCollector(context);
+    }
+
+    @Test
+    public void TestHandleReplyCompletesSuccessfullyWithDeleteIdHandler(final TestContext context) {
+        TestServerComponents server = setUpBasicApiServer(context);
+        TestMetricsCollector metricsCollector = setUpMetricsCollector(context);
+        ConcurrentLinkedQueue<CoordinationMessage> deadLetter = new ConcurrentLinkedQueue<>();
+        State state = createState(deadLetter);
+        DeleteReplyHandler handler = getDeleteReplyHandler(state);
+
+        Async async = context.async();
+        handler.handleReply(DELETE_ID, DEFAULT_SEVER_CONFIG)
+            .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(1000, v1 -> {
+                metricsCollector.testHasExpectedStatusSize(1);
+                Assert.assertEquals(0, state.getMessages().getNumberOfMessages());
+                Assert.assertEquals(0, deadLetter.size());
+                async.complete();
+            })));
+        async.awaitSuccess();
+        tearDownServer(context, server);
+        metricsCollector.tearDownMetricsCollector(context);
+    }
+
+    @Test
+    public void TestHandleReplyFails(final TestContext context) {
+        TestMetricsCollector metricsCollector = setUpMetricsCollector(context);
+        ConcurrentLinkedQueue<CoordinationMessage> deadLetter = new ConcurrentLinkedQueue<>();
+        State state = createState(deadLetter);
+        DeleteReplyHandler handler = getDeleteReplyHandler(state);
+
+        Async async = context.async();
+        handler.handleReply(DELETE_ID, DEFAULT_SEVER_CONFIG)
+            .onComplete(context.asyncAssertFailure(cause -> vertx.setTimer(1000, v1 -> {
+                metricsCollector.testHasExpectedStatusSize(1);
+                Assert.assertEquals(CONNECTION_REFUSED_EXCEPTION, cause.getMessage());
+                Assert.assertEquals(0, state.getMessages().getNumberOfMessages());
+                Assert.assertEquals(1, deadLetter.size());
+                async.complete();
+            })));
+        async.awaitSuccess();
+        metricsCollector.tearDownMetricsCollector(context);
+    }
+
+    private DeleteReplyHandler getDeleteReplyHandler() {
+        return getDeleteReplyHandler(createState());
+    }
+
+    private DeleteReplyHandler getDeleteReplyHandler(final State state) {
+        return new DeleteReplyHandler(createServerClient(), state, createTestRegistryManager(), new GossipConfiguration());
+    }
+}

--- a/gossip/src/test/java/io/julian/gossip/delete/DeleteReplyHandlerTest.java
+++ b/gossip/src/test/java/io/julian/gossip/delete/DeleteReplyHandlerTest.java
@@ -26,7 +26,7 @@ public class DeleteReplyHandlerTest extends AbstractHandlerTest {
         CoordinationMessage message = handler.getCoordinationMessage(DELETE_ID, HAS_PROCESSED);
 
         Assert.assertEquals(HTTPRequest.DELETE, message.getMetadata().getRequest());
-        Assert.assertEquals(DeleteReplyHandler.TYPE, message.getMetadata().getType());
+        Assert.assertEquals(DeleteReplyHandler.DELETE_REPLY_TYPE, message.getMetadata().getType());
         Assert.assertEquals(DELETE_ID + "-delete-reply", message.getMetadata().getMessageID());
         Assert.assertEquals(new UpdateResponse(DELETE_ID, HAS_PROCESSED).toJson().encodePrettily(), message.getDefinition().encodePrettily());
     }

--- a/gossip/src/test/java/io/julian/gossip/models/UpdateResponseTest.java
+++ b/gossip/src/test/java/io/julian/gossip/models/UpdateResponseTest.java
@@ -13,11 +13,11 @@ public class UpdateResponseTest {
         UpdateResponse response = new UpdateResponse(ID, CONTAINS_ID);
 
         Assert.assertEquals(ID, response.getMessageId());
-        Assert.assertEquals(CONTAINS_ID, response.getDoesContainId());
+        Assert.assertEquals(CONTAINS_ID, response.getHasProcessedId());
 
         JsonObject expected = new JsonObject()
             .put("messageId", ID)
-            .put("doesContainId", true);
+            .put("hasProcessedId", true);
         Assert.assertEquals(expected.encodePrettily(), response.toJson().encodePrettily());
     }
 }

--- a/gossip/src/test/java/io/julian/gossip/verticle/RetryVerticleTest.java
+++ b/gossip/src/test/java/io/julian/gossip/verticle/RetryVerticleTest.java
@@ -51,7 +51,7 @@ public class RetryVerticleTest extends AbstractHandlerTest {
 
     @Test
     public void TestRetryVerticleCoordinationMessageIsSuccessful(final TestContext context) {
-        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        TestServerComponents server = setUpBasicApiServer(context);
         ConcurrentLinkedQueue<CoordinationMessage> deadLetters = new ConcurrentLinkedQueue<>();
         MessageStore messages = new MessageStore();
         messages.putMessage(MESSAGE_ID, new JsonObject());

--- a/gossip/src/test/java/io/julian/gossip/write/WriteHandlerTest.java
+++ b/gossip/src/test/java/io/julian/gossip/write/WriteHandlerTest.java
@@ -102,11 +102,11 @@ public class WriteHandlerTest extends AbstractHandlerTest {
         WriteHandler handler = createWriteHandler(state, configuration);
 
         Async async = context.async();
-        handler.sendMessageIfNotInactive(new UpdateResponse(MESSAGE_ID, true))
+        handler.sendPostIfNotInactive(new UpdateResponse(MESSAGE_ID, true))
             .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(500, v1 -> {
                 collector.testHasExpectedStatusSize(1);
                 Assert.assertEquals(1, messages.getNumberOfMessages());
-                Assert.assertEquals(0, state.getInactiveIds().size());
+                Assert.assertEquals(0, state.getInactivePostIds().size());
                 async.complete();
             })));
         async.awaitSuccess();
@@ -125,10 +125,10 @@ public class WriteHandlerTest extends AbstractHandlerTest {
         WriteHandler handler = createWriteHandler(state, configuration);
 
         Async async = context.async();
-        handler.sendMessageIfNotInactive(new UpdateResponse(MESSAGE_ID, true))
+        handler.sendPostIfNotInactive(new UpdateResponse(MESSAGE_ID, true))
             .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(500, v1 -> {
                 collector.testHasExpectedStatusSize(0);
-                Assert.assertEquals(1, state.getInactiveIds().size());
+                Assert.assertEquals(1, state.getInactivePostIds().size());
                 async.complete();
             })));
         async.awaitSuccess();
@@ -147,10 +147,10 @@ public class WriteHandlerTest extends AbstractHandlerTest {
         WriteHandler handler = createWriteHandler(state, configuration);
 
         Async async = context.async();
-        handler.sendMessageIfNotInactive(new UpdateResponse(MESSAGE_ID, true))
+        handler.sendPostIfNotInactive(new UpdateResponse(MESSAGE_ID, true))
             .onComplete(context.asyncAssertSuccess(v -> vertx.setTimer(500, v1 -> {
                 collector.testHasExpectedStatusSize(0);
-                Assert.assertEquals(0, state.getInactiveIds().size());
+                Assert.assertEquals(0, state.getInactivePostIds().size());
                 async.complete();
             })));
         async.awaitSuccess();

--- a/gossip/src/test/java/io/julian/gossip/write/WriteReplyHandlerTest.java
+++ b/gossip/src/test/java/io/julian/gossip/write/WriteReplyHandlerTest.java
@@ -1,5 +1,6 @@
 package io.julian.gossip.write;
 
+import io.julian.gossip.components.GossipConfiguration;
 import io.julian.gossip.components.State;
 import io.julian.gossip.models.UpdateResponse;
 import io.julian.server.components.MessageStore;
@@ -33,7 +34,7 @@ public class WriteReplyHandlerTest extends AbstractHandlerTest {
     @Test
     public void TestHandleReplySuccessfullySendNoMessageResponse(final TestContext context) {
         TestMetricsCollector collector = setUpMetricsCollector(context);
-        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        TestServerComponents server = setUpBasicApiServer(context);
 
         MessageStore messages = new MessageStore();
         ConcurrentLinkedQueue<CoordinationMessage> deadLetters = new ConcurrentLinkedQueue<>();
@@ -54,7 +55,7 @@ public class WriteReplyHandlerTest extends AbstractHandlerTest {
     @Test
     public void TestHandleReplySuccessfullyRepliesAndDoesNotAddIfAlreadyAdded(final TestContext context) {
         TestMetricsCollector collector = setUpMetricsCollector(context);
-        TestServerComponents server = setUpBasicApiServer(context, DEFAULT_SEVER_CONFIG);
+        TestServerComponents server = setUpBasicApiServer(context);
 
         MessageStore messages = new MessageStore();
         messages.putMessage(MESSAGE_ID, new JsonObject());
@@ -96,6 +97,6 @@ public class WriteReplyHandlerTest extends AbstractHandlerTest {
     }
 
     private WriteReplyHandler createWriteReplyHandler(final State state) {
-        return new WriteReplyHandler(createServerClient(), state);
+        return new WriteReplyHandler(createServerClient(), state, createTestRegistryManager(), new GossipConfiguration());
     }
 }

--- a/gossip/src/test/java/tools/AbstractHandlerTest.java
+++ b/gossip/src/test/java/tools/AbstractHandlerTest.java
@@ -42,9 +42,9 @@ public abstract class AbstractHandlerTest {
         return components;
     }
 
-    protected TestServerComponents setUpBasicApiServer(final TestContext context, final ServerConfiguration configuration) {
+    protected TestServerComponents setUpBasicApiServer(final TestContext context) {
         TestServerComponents components = new TestServerComponents();
-        components.setUpBasicServer(context, vertx, configuration);
+        components.setUpBasicServer(context, vertx, AbstractHandlerTest.DEFAULT_SEVER_CONFIG);
         return components;
     }
 

--- a/gossip/src/test/java/tools/TestClient.java
+++ b/gossip/src/test/java/tools/TestClient.java
@@ -30,4 +30,18 @@ public class TestClient {
             });
         return response.future();
     }
+
+    public Future<HttpResponse<Buffer>> DELETE_MESSAGE(final String host, final int port, final String messageId) {
+        Promise<HttpResponse<Buffer>> response = Promise.promise();
+        client
+            .delete(port, host, String.format("%s/?messageId=%s", CLIENT_URI, messageId))
+            .send(res -> {
+                if (res.succeeded()) {
+                    response.complete(res.result());
+                } else {
+                    response.fail(res.cause());
+                }
+            });
+        return response.future();
+    }
 }

--- a/gossip/src/test/java/tools/TestMetricsCollector.java
+++ b/gossip/src/test/java/tools/TestMetricsCollector.java
@@ -44,8 +44,4 @@ public class TestMetricsCollector {
     public void testHasExpectedStatusSize(final int expectedSize) {
         Assert.assertEquals(expectedSize, server.getTracker().getStatuses().size());
     }
-
-    public void testHasExpectedStatusSizeGreaterThan(final int expectedSize) {
-        Assert.assertTrue(server.getTracker().getStatuses().size() >= expectedSize);
-    }
 }


### PR DESCRIPTION
Added the ability to delete messages from the server. This is done by creating a marker for inactive delete IDs and ids that shouldn't be added. This has been added into the WriteHandler to make sure it doesn't add deleted Ids.

Closes: #64 

Signed-off-by: Julian Goh <juliangohsl@gmail.com>