### PR TITLE
feat: add the ability to track time difference

### DIFF
--- a/metrics-collector/src/main/java/io/julian/metrics/collector/report/filters/GenericStatistics.java
+++ b/metrics-collector/src/main/java/io/julian/metrics/collector/report/filters/GenericStatistics.java
@@ -12,6 +12,7 @@ public class GenericStatistics {
     public final static String TOTAL_MESSAGES_KEY = "Total Messages";
     public final static String TOTAL_FAILED_MESSAGES_KEY = "Total Failed Messages";
     public final static String TOTAL_SUCCEEDED_MESSAGES_KEY = "Total Succeeded Messages";
+    public final static String TOTAL_TIME_KEY = "Total Time";
 
     public String toReportEntry(final MessageStatus messageStatus) {
         log.traceEntry(() -> messageStatus);
@@ -23,6 +24,7 @@ public class GenericStatistics {
         builder.appendLine(String.format("%s: %d", TOTAL_MESSAGES_KEY, totalMessages));
         builder.appendLine(String.format("%s: %d", TOTAL_FAILED_MESSAGES_KEY, messageStatus.getFailedMessages()));
         builder.appendLine(String.format("%s: %d", TOTAL_SUCCEEDED_MESSAGES_KEY, messageStatus.getSuccessfulMessages()));
+        builder.appendLine(String.format("%s: %s", TOTAL_TIME_KEY, messageStatus.getTimeDifference()));
         builder.appendLine("");
 
         return log.traceExit(builder.toString());

--- a/metrics-collector/src/main/java/io/julian/metrics/collector/tracking/MessageStatus.java
+++ b/metrics-collector/src/main/java/io/julian/metrics/collector/tracking/MessageStatus.java
@@ -4,6 +4,8 @@ import io.julian.metrics.collector.models.TrackedMessage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -12,6 +14,8 @@ public class MessageStatus {
     private final AtomicReference<Float> totalMessageSize = new AtomicReference<>(0f);
     private final AtomicInteger failedMessages = new AtomicInteger();
     private final AtomicInteger successfulMessages = new AtomicInteger();
+    private final LocalDateTime startingTime = LocalDateTime.now();
+    private final AtomicReference<LocalDateTime> lastMessageTime = new AtomicReference<>(LocalDateTime.now());
 
     public void addTrackedMessage(final TrackedMessage message) {
         log.traceEntry(() -> message);
@@ -21,7 +25,15 @@ public class MessageStatus {
         } else {
             failedMessages.incrementAndGet();
         }
+        lastMessageTime.set(LocalDateTime.now());
         log.traceExit();
+    }
+
+    public String getTimeDifference() {
+        log.traceEntry();
+        long minute = ChronoUnit.MINUTES.between(startingTime, lastMessageTime.get());
+        long seconds = ChronoUnit.SECONDS.between(startingTime, lastMessageTime.get()) % 60;
+        return log.traceExit(String.format("%d minutes:%d seconds", minute, seconds));
     }
 
     public float getTotalMessageSize() {

--- a/metrics-collector/src/test/java/io/julian/metrics/collector/report/ReportCreatorTest.java
+++ b/metrics-collector/src/test/java/io/julian/metrics/collector/report/ReportCreatorTest.java
@@ -43,6 +43,7 @@ public class ReportCreatorTest {
             String.format("%s: 1\n", GenericStatistics.TOTAL_MESSAGES_KEY) +
             String.format("%s: 0\n", GenericStatistics.TOTAL_FAILED_MESSAGES_KEY) +
             String.format("%s: 1\n", GenericStatistics.TOTAL_SUCCEEDED_MESSAGES_KEY) +
+            String.format("%s: 0 minutes:0 seconds\n", GenericStatistics.TOTAL_TIME_KEY) +
             "\n";
 
         Assert.assertEquals(expectedReport, creator.createReport(ReportCreator.GENERAL_STATISTIC_FILTER_NAME));

--- a/metrics-collector/src/test/java/io/julian/metrics/collector/report/filters/GenericStatisticsTest.java
+++ b/metrics-collector/src/test/java/io/julian/metrics/collector/report/filters/GenericStatisticsTest.java
@@ -17,6 +17,7 @@ public class GenericStatisticsTest {
             String.format("%s: 1\n", GenericStatistics.TOTAL_MESSAGES_KEY) +
             String.format("%s: 0\n", GenericStatistics.TOTAL_FAILED_MESSAGES_KEY) +
             String.format("%s: 1\n", GenericStatistics.TOTAL_SUCCEEDED_MESSAGES_KEY) +
+            String.format("%s: 0 minutes:0 seconds\n", GenericStatistics.TOTAL_TIME_KEY) +
             "\n";
 
         GenericStatistics statistics = new GenericStatistics();

--- a/metrics-collector/src/test/java/io/julian/metrics/collector/tracking/MessageStatusTest.java
+++ b/metrics-collector/src/test/java/io/julian/metrics/collector/tracking/MessageStatusTest.java
@@ -1,12 +1,32 @@
 package io.julian.metrics.collector.tracking;
 
 import io.julian.metrics.collector.models.TrackedMessage;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(VertxUnitRunner.class)
 public class MessageStatusTest {
     private final static TrackedMessage SUCCESSFUL_MESSAGE = new TrackedMessage(200, "random-id", 10.5f);
     private final static TrackedMessage FAILED_MESSAGE = new TrackedMessage(404, "random-id", 200f);
+
+    private Vertx vertx;
+
+    @Before
+    public void before() {
+        this.vertx = Vertx.vertx();
+    }
+
+    @After
+    public void after() {
+        this.vertx.close();
+    }
 
     @Test
     public void TestInit() {
@@ -14,23 +34,38 @@ public class MessageStatusTest {
         Assert.assertEquals(0, status.getFailedMessages());
         Assert.assertEquals(0, status.getTotalMessageSize(), 0);
         Assert.assertEquals(0, status.getSuccessfulMessages());
+        Assert.assertEquals("0 minutes:0 seconds", status.getTimeDifference());
     }
 
     @Test
-    public void TestAddSuccessfulMessage() {
+    public void TestAddSuccessfulMessage(final TestContext context) {
         MessageStatus status = new MessageStatus();
-        status.addTrackedMessage(SUCCESSFUL_MESSAGE);
-        Assert.assertEquals(0, status.getFailedMessages());
-        Assert.assertEquals(SUCCESSFUL_MESSAGE.getMessageSize(), status.getTotalMessageSize(), 0);
-        Assert.assertEquals(1, status.getSuccessfulMessages());
+
+        Async async = context.async();
+        vertx.setPeriodic(1000, id -> {
+            status.addTrackedMessage(SUCCESSFUL_MESSAGE);
+            Assert.assertEquals(0, status.getFailedMessages());
+            Assert.assertEquals(SUCCESSFUL_MESSAGE.getMessageSize(), status.getTotalMessageSize(), 0);
+            Assert.assertEquals(1, status.getSuccessfulMessages());
+            Assert.assertEquals("0 minutes:1 seconds", status.getTimeDifference());
+            async.complete();
+        });
+        async.awaitSuccess();
     }
 
     @Test
-    public void TestAddFailedMessage() {
+    public void TestAddFailedMessage(final TestContext context) {
         MessageStatus status = new MessageStatus();
-        status.addTrackedMessage(FAILED_MESSAGE);
-        Assert.assertEquals(1, status.getFailedMessages());
-        Assert.assertEquals(FAILED_MESSAGE.getMessageSize(), status.getTotalMessageSize(), 0);
-        Assert.assertEquals(0, status.getSuccessfulMessages());
+        Async async = context.async();
+        vertx.setPeriodic(1000, id -> {
+            status.addTrackedMessage(FAILED_MESSAGE);
+            Assert.assertEquals(1, status.getFailedMessages());
+            Assert.assertEquals(FAILED_MESSAGE.getMessageSize(), status.getTotalMessageSize(), 0);
+            Assert.assertEquals(0, status.getSuccessfulMessages());
+            Assert.assertEquals("0 minutes:1 seconds", status.getTimeDifference());
+            async.complete();
+        });
+
+        async.awaitSuccess();
     }
 }


### PR DESCRIPTION
Now metrics collector will track the total time taken for the exchange of messages.

Closes: #66

Signed-off-by: Julian Goh <juliangohsl@gmail.com>